### PR TITLE
Optimize PNG save pipeline

### DIFF
--- a/DMISharp.Benchmark/DMISaveBenchmarks.cs
+++ b/DMISharp.Benchmark/DMISaveBenchmarks.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Order;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace DMISharp.Benchmark;
+
+[MemoryDiagnoser]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[SimpleJob(RuntimeMoniker.Net80, warmupCount: 3, iterationCount: 5)]
+public class DMISaveBenchmarks
+{
+    private const int FrameSize = 32;
+    private const int FrameCount = 256;
+
+    private DMIFile _paletteFile = null!;
+    private DMIFile _trueColorFile = null!;
+
+    public enum SaveInput
+    {
+        Palette,
+        TrueColor
+    }
+
+    [ParamsAllValues]
+    public SaveInput Input { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _paletteFile = CreateFile(CreatePaletteFrame);
+        _trueColorFile = CreateFile(CreateTrueColorFrame);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _paletteFile.Dispose();
+        _trueColorFile.Dispose();
+    }
+
+    [Benchmark]
+    public long Save()
+    {
+        using var stream = new MemoryStream();
+        GetFile().Save(stream);
+        return stream.Length;
+    }
+
+    private DMIFile GetFile() => Input == SaveInput.Palette ? _paletteFile : _trueColorFile;
+
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
+    private static DMIFile CreateFile(Func<int, Image<Rgba32>> createFrame)
+    {
+        var file = new DMIFile(FrameSize, FrameSize);
+        var state = new DMIState("benchmark", DirectionDepth.One, FrameCount, FrameSize, FrameSize);
+
+        for (var frame = 0; frame < FrameCount; frame++)
+            state.SetFrame(createFrame(frame), frame);
+
+        file.AddState(state);
+        return file;
+    }
+
+    private static Image<Rgba32> CreatePaletteFrame(int frame)
+    {
+        var image = new Image<Rgba32>(FrameSize, FrameSize);
+        image.ProcessPixelRows(accessor =>
+        {
+            for (var y = 0; y < FrameSize; y++)
+            {
+                var row = accessor.GetRowSpan(y);
+                for (var x = 0; x < FrameSize; x++)
+                {
+                    var color = (byte)((x / 4 + y / 4 + frame) & 15);
+                    row[x] = new Rgba32(
+                        (byte)(color * 17),
+                        (byte)((color * 53) & 255),
+                        (byte)((color * 97) & 255),
+                        color == 0 ? (byte)0 : byte.MaxValue);
+                }
+            }
+        });
+        return image;
+    }
+
+    private static Image<Rgba32> CreateTrueColorFrame(int frame)
+    {
+        var image = new Image<Rgba32>(FrameSize, FrameSize);
+        image.ProcessPixelRows(accessor =>
+        {
+            var value = (uint)(frame + 1);
+            for (var y = 0; y < FrameSize; y++)
+            {
+                var row = accessor.GetRowSpan(y);
+                for (var x = 0; x < FrameSize; x++)
+                {
+                    value ^= value << 13;
+                    value ^= value >> 17;
+                    value ^= value << 5;
+                    row[x] = new Rgba32(
+                        (byte)value,
+                        (byte)(value >> 8),
+                        (byte)(value >> 16),
+                        byte.MaxValue);
+                }
+            }
+        });
+        return image;
+    }
+}

--- a/DMISharp.Tests/DMIWriteTests.cs
+++ b/DMISharp.Tests/DMIWriteTests.cs
@@ -9,6 +9,48 @@ namespace DMISharp.Tests;
 
 public class DMIWriteTests
 {
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SaveProducesIdenticalOutputAcrossStreamCapabilities(bool trueColor)
+    {
+        using var file = CreateSyntheticFile(trueColor);
+        using var expectedStream = new MemoryStream();
+        file.Save(expectedStream);
+        var expected = expectedStream.ToArray();
+
+        var prefix = new byte[] { 1, 2, 3, 4 };
+        using var appendStream = new MemoryStream();
+        appendStream.Write(prefix);
+        file.Save(appendStream);
+        Assert.Equal(prefix.Concat(expected), appendStream.ToArray());
+
+        using var nonSeekableOutput = new MemoryStream();
+        using (var nonSeekableStream = new NonSeekableWriteStream(nonSeekableOutput))
+            file.Save(nonSeekableStream);
+        Assert.Equal(expected, nonSeekableOutput.ToArray());
+
+        var overwriteBuffer = Enumerable.Repeat((byte)0xA5, expected.Length + 64).ToArray();
+        using var overwriteStream = new MemoryStream(overwriteBuffer, writable: true);
+        file.Save(overwriteStream);
+        Assert.Equal(expected, overwriteBuffer.Take(expected.Length));
+        Assert.All(overwriteBuffer.Skip(expected.Length), value => Assert.Equal(0xA5, value));
+    }
+
+    [Fact]
+    public void SaveKeepsUnusedAtlasCellsTransparent()
+    {
+        using var file = CreateSyntheticFile(false, 3);
+        using var output = new MemoryStream();
+        file.Save(output);
+        output.Position = 0;
+
+        using var image = Image.Load<Rgba32>(output);
+        Assert.Equal(34, image.Width);
+        Assert.Equal(34, image.Height);
+        Assert.Equal(0, image[33, 33].A);
+    }
+
     [Fact]
     public void CanWriteDMIFile()
     {
@@ -212,5 +254,79 @@ public class DMIWriteTests
         });
 
         Assert.Equal(0, pixelDiffs);
+    }
+
+    private static DMIFile CreateSyntheticFile(bool trueColor, int frameCount = 1)
+    {
+        const int frameSize = 17;
+        var file = new DMIFile(frameSize, frameSize);
+#pragma warning disable CA2000
+        var state = new DMIState("synthetic", DirectionDepth.One, frameCount, frameSize, frameSize);
+#pragma warning restore CA2000
+
+        for (var frame = 0; frame < frameCount; frame++)
+        {
+#pragma warning disable CA2000
+            var image = new Image<Rgba32>(frameSize, frameSize);
+#pragma warning restore CA2000
+            image.ProcessPixelRows(accessor =>
+            {
+                for (var y = 0; y < frameSize; y++)
+                {
+                    var row = accessor.GetRowSpan(y);
+                    for (var x = 0; x < frameSize; x++)
+                    {
+                        row[x] = trueColor
+                            ? new Rgba32((byte)x, (byte)y, (byte)(y * frameSize + x), byte.MaxValue)
+                            : new Rgba32((byte)((x + y + frame) % 16 * 17), 64, 128, byte.MaxValue);
+                    }
+                }
+            });
+            state.SetFrame(image, frame);
+        }
+
+        file.AddState(state);
+        return file;
+    }
+
+    private sealed class NonSeekableWriteStream : Stream
+    {
+        private readonly Stream _inner;
+
+        public NonSeekableWriteStream(Stream inner)
+        {
+            _inner = inner;
+        }
+
+        public override bool CanRead => false;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => true;
+
+        public override long Length => throw new System.NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new System.NotSupportedException();
+            set => throw new System.NotSupportedException();
+        }
+
+        public override void Flush() => _inner.Flush();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _inner.Dispose();
+            base.Dispose(disposing);
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new System.NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new System.NotSupportedException();
+
+        public override void SetLength(long value) => throw new System.NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => _inner.Write(buffer, offset, count);
     }
 }

--- a/DMISharp/DMIFile.cs
+++ b/DMISharp/DMIFile.cs
@@ -1,6 +1,5 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -85,27 +84,9 @@ public sealed class DMIFile : IDisposable, IExportable
     {
         if (dataStream == null) throw new ArgumentNullException(nameof(dataStream), "Target stream cannot be null!");
 
-        // prepare frames
-        var frames = new List<Image<Rgba32>>();
-        foreach (var state in States)
-        {
-            for (var frame = 0; frame < state.Frames; frame++)
-            {
-                for (var dir = 0; dir < state.Dirs; dir++)
-                {
-                    var foundFrame = state.GetFrame((StateDirection)dir, frame);
-                    if (foundFrame != null)
-                        frames.Add(foundFrame);
-                    else
-                        throw new InvalidOperationException(
-                            $"Failed to get frame for state: {dir} frame {frame} is null");
-                }
-            }
-        }
-
         // Get dimensions in frames using the same logic that BYOND does internally (adapted from byondcore.dll)
         // (more specifically from iconToPixels)
-        var numFrames = frames.Count;
+        var numFrames = States.Sum(state => state.Frames * state.Dirs);
         var xRatio = Math.Sqrt((double)Metadata.FrameHeight * numFrames / Metadata.FrameWidth);
         var yRatio = Math.Sqrt((double)Metadata.FrameWidth * numFrames / Metadata.FrameHeight);
 
@@ -130,62 +111,69 @@ public sealed class DMIFile : IDisposable, IExportable
         var xFrames = (int)(xRatio + 0.5);
         var yFrames = (int)(intermediateY2 + 0.5);
 
+        // Build the atlas and analyze its colors in one pass.
+        var hasTransparency = false;
+        var pristineGreyscale = true;
+        var colors = new HashSet<uint>();
+        var paletteCompatible = true;
+        var transparent = Color.Transparent;
         using var img = new Image<Rgba32>(xFrames * Metadata.FrameWidth, yFrames * Metadata.FrameHeight);
-        for (int y = 0, i = 0; y < yFrames && i < numFrames; y++)
+        var frameIndex = 0;
+        foreach (var state in States)
         {
-            for (var x = 0; x < xFrames && i < numFrames; x++, i++)
+            for (var frame = 0; frame < state.Frames; frame++)
             {
-                var targetFrame = frames[i];
-                var yCap = y; // For closure
-                var xCap = x; // For closure
-                img.ProcessPixelRows(targetFrame, (imgAccessor, targetAccessor) =>
+                for (var dir = 0; dir < state.Dirs; dir++)
                 {
-                    for (var ypx = 0; ypx < Metadata.FrameHeight; ypx++)
+                    var sourceFrame = state.GetFrame((StateDirection)dir, frame);
+                    if (sourceFrame == null)
+                        throw new InvalidOperationException(
+                            $"Failed to get frame for state: {dir} frame {frame} is null");
+
+                    var atlasX = frameIndex % xFrames * Metadata.FrameWidth;
+                    var atlasY = frameIndex / xFrames * Metadata.FrameHeight;
+                    img.ProcessPixelRows(sourceFrame, (imgAccessor, sourceAccessor) =>
                     {
-                        var sourceSpan = targetAccessor.GetRowSpan(ypx);
-                        var destSpan = imgAccessor.GetRowSpan(ypx + yCap * Metadata.FrameHeight);
-                        sourceSpan.CopyTo(destSpan.Slice(xCap * Metadata.FrameWidth, Metadata.FrameWidth));
-                    }
-                });
+                        for (var ypx = 0; ypx < Metadata.FrameHeight; ypx++)
+                        {
+                            var sourceSpan = sourceAccessor.GetRowSpan(ypx);
+                            var destSpan = imgAccessor.GetRowSpan(ypx + atlasY)
+                                .Slice(atlasX, Metadata.FrameWidth);
+                            sourceSpan.CopyTo(destSpan);
+
+                            for (var xpx = 0; xpx < destSpan.Length; xpx++)
+                            {
+                                ref var pixel = ref destSpan[xpx];
+
+                                if (!hasTransparency && pixel.A < byte.MaxValue)
+                                    hasTransparency = true;
+
+                                if (pixel.A == 0)
+                                    pixel.FromRgba32(transparent);
+
+                                if (pristineGreyscale && !(pixel.R == pixel.G && pixel.G == pixel.B))
+                                    pristineGreyscale = false;
+
+                                if (paletteCompatible && colors.Add(pixel.PackedValue) && colors.Count > 256)
+                                    paletteCompatible = false;
+                            }
+                        }
+                    });
+                    frameIndex++;
+                }
             }
+        }
+
+        // BYOND's layout can leave unused atlas cells, which remain transparent black.
+        if (frameIndex < xFrames * yFrames)
+        {
+            hasTransparency = true;
+            if (paletteCompatible && colors.Add(default(Rgba32).PackedValue) && colors.Count > 256)
+                paletteCompatible = false;
         }
 
         var md = img.Metadata.GetFormatMetadata(PngFormat.Instance);
         md.TextData.Add(new PngTextData("Description", GetTextChunk(), string.Empty, string.Empty));
-
-        // Perform some brief analysis to determine optimal color type for saving
-        var hasTransparency = false;
-        var pristineGreyscale = true;
-        var colors = new HashSet<uint>();
-        var transparent = Color.Transparent;
-        var height = img.Height;
-        var width = img.Width;
-        img.ProcessPixelRows(accessor =>
-        {
-            for (var ypx = 0; ypx < height; ypx++)
-            {
-                var row = accessor.GetRowSpan(ypx);
-                for (var xpx = 0; xpx < width; xpx++)
-                {
-                    ref var pixel = ref row[xpx];
-
-                    // Check for transparency, if we ultimately don't have any we can remove the alpha layer
-                    if (!hasTransparency && pixel.A < byte.MaxValue)
-                        hasTransparency = true;
-
-                    // Set color to be transparent black if fully transparent
-                    if (pixel.A == 0)
-                        pixel.FromRgba32(transparent);
-
-                    // Check for greyscale pristine-ness
-                    if (pristineGreyscale && !(pixel.R == pixel.G && pixel.G == pixel.B))
-                        pristineGreyscale = false;
-
-                    // Count distinct colors to determine best approach with palette
-                    colors.Add(pixel.PackedValue);
-                }
-            }
-        });
 
         // Determine color type
         PngColorType? colorType = null;
@@ -211,14 +199,13 @@ public sealed class DMIFile : IDisposable, IExportable
         };
 
         // If there is no possibility of a color palette we can return at this point
-        if (colors.Count > 256)
+        if (!paletteCompatible)
         {
             img.SaveAsPng(dataStream, pngEncoder);
             return;
         }
 
         // We can use a color palette
-        var colorSpan = colors.ToImmutableArray().AsSpan();
         var paletteEncoder = new PngEncoder()
         {
             InterlaceMethod = pngEncoder.InterlaceMethod,
@@ -230,17 +217,48 @@ public sealed class DMIFile : IDisposable, IExportable
             ColorType = PngColorType.Palette,
             Quantizer = new NoFrillsQuantizer(colors.Select(x => new Color(new Rgba32(x))).ToArray(),
                 new QuantizerOptions() { Dither = null }),
-            BitDepth = GetBitDepth(colorSpan)
+            BitDepth = GetBitDepth(colors.Count)
         };
 
-        // Test to see if the default saving or palette is smaller, then use the smallest of the two
+        // Appending to a resizable stream lets the palette candidate be written directly. If the normal
+        // candidate is smaller, it safely replaces the appended bytes without touching existing data.
+        if (dataStream is MemoryStream or FileStream
+            && dataStream.Position == dataStream.Length)
+        {
+            var outputStart = dataStream.Position;
+            try
+            {
+                img.SaveAsPng(dataStream, paletteEncoder);
+                var paletteLength = dataStream.Position - outputStart;
+
+                using var normalMs = new MemoryStream();
+                img.SaveAsPng(normalMs, pngEncoder);
+                if (normalMs.Length <= paletteLength)
+                {
+                    dataStream.Position = outputStart;
+                    normalMs.Position = 0;
+                    normalMs.CopyTo(dataStream);
+                    dataStream.SetLength(dataStream.Position);
+                }
+            }
+            catch
+            {
+                dataStream.SetLength(outputStart);
+                dataStream.Position = outputStart;
+                throw;
+            }
+
+            return;
+        }
+
+        // Preserve overwrite and non-seekable stream behavior by buffering both candidates.
         using var paletteMs = new MemoryStream();
-        using var normalMs = new MemoryStream();
+        using var bufferedNormalMs = new MemoryStream();
 
         img.SaveAsPng(paletteMs, paletteEncoder);
-        img.SaveAsPng(normalMs, pngEncoder);
+        img.SaveAsPng(bufferedNormalMs, pngEncoder);
 
-        var smallest = paletteMs.Length < normalMs.Length ? paletteMs : normalMs;
+        var smallest = paletteMs.Length < bufferedNormalMs.Length ? paletteMs : bufferedNormalMs;
         smallest.Seek(0, SeekOrigin.Begin);
         smallest.CopyTo(dataStream);
     }
@@ -453,9 +471,9 @@ public sealed class DMIFile : IDisposable, IExportable
         toCheck.Height == Metadata.FrameHeight
         && toCheck.Width == Metadata.FrameWidth;
 
-    private static PngBitDepth GetBitDepth(ReadOnlySpan<uint> colors)
+    private static PngBitDepth GetBitDepth(int colorCount)
     {
-        return colors.Length switch
+        return colorCount switch
         {
             <= 2 => PngBitDepth.Bit1,
             <= 4 => PngBitDepth.Bit2,


### PR DESCRIPTION
## Summary

- bound distinct-color tracking once a palette is no longer possible
- build and analyze the PNG atlas in one pass, avoiding the temporary frame list and redundant full-atlas scan
- write the palette candidate directly to append-only `MemoryStream`/`FileStream` outputs while buffering only the competing normal candidate
- preserve fallback behavior for overwrite and non-seekable streams
- add deterministic palette and true-color save benchmarks plus focused stream and atlas-padding tests

## Benchmark results

BenchmarkDotNet 0.13.12 on Windows 11, AMD Ryzen 7 5800X3D, .NET 8.0.28, workstation GC. Each case saves a preconstructed DMI containing 256 deterministic 32x32 frames to a new `MemoryStream`, isolating save work from file parsing. Results use 3 warmups and 5 measured iterations with `MemoryDiagnoser`.

| Stage | Palette mean | Palette allocated | True-color mean | True-color allocated |
|---|---:|---:|---:|---:|
| Baseline | 16.88 ms | 105.76 KB | 43.45 ms | 14,696.46 KB |
| Bounded color tracking | 16.68 ms | 105.78 KB | 28.55 ms | 4,926.06 KB |
| Fused atlas copy and analysis | 15.74 ms | 101.55 KB | 26.48 ms | 4,921.97 KB |
| Final candidate | 14.79 ms | 100.25 KB | 25.08 ms | 4,921.16 KB |

Final versus baseline:

| Input | Wall-time reduction | Managed-allocation reduction |
|---|---:|---:|
| Palette | 12.4% | 5.2% |
| True-color | 42.3% | 66.5% |

## Correctness guarantees

- frame ordering and BYOND atlas dimension calculation are unchanged
- decoded pixels and DMI metadata remain equivalent
- fully transparent pixels are still normalized to transparent black
- unused atlas cells remain transparent and participate in color-type selection
- palette-compatible output still compares palette and normal PNG encodings and emits the smaller result
- append, overwrite, and non-seekable stream behavior is covered for palette and true-color inputs
- direct-output failures restore the original append stream length and position before propagating the exception

## Tradeoffs

- the atlas allocation and frame copies remain necessary because public state frames are independently mutable `Image<Rgba32>` instances; caching an atlas would risk stale output
- palette-compatible images are still encoded in both forms because preserving the smaller-output choice requires knowing both sizes; the optimization removes one full temporary PNG buffer and final copy for common append-only `MemoryStream` and `FileStream` destinations
- arbitrary seekable stream implementations retain the conservative buffered path because seekability alone does not guarantee safe resizing or rollback semantics
- PNG binary bytes and palette order are not guaranteed to match previous output, but decoded content, metadata, and public save behavior are preserved

## Validation

- 28/28 .NET 8 tests pass
- full `net6.0`, `net7.0`, and `net8.0` solution build succeeds
- generated BenchmarkDotNet artifacts remain excluded by `.gitignore`