### PR TITLE
Optimize state collection operations

### DIFF
--- a/DMISharp.Benchmark/DMIStateOperationBenchmarks.cs
+++ b/DMISharp.Benchmark/DMIStateOperationBenchmarks.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using System.Globalization;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+#pragma warning disable CA1001, CA1024, CA2000
+
+namespace DMISharp.Benchmark;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+public class ImportStatesBenchmarks
+{
+    private DMIFile _destination = null!;
+    private DMIFile _source = null!;
+
+    [Params(128, 1024, 4096)]
+    public int StateCount { get; set; }
+
+    [IterationSetup]
+    public void Setup()
+    {
+        _destination = new DMIFile(1, 1);
+        _source = new DMIFile(1, 1);
+
+        for (var i = 0; i < StateCount; i++)
+        {
+            _source.AddState(new DMIState(i.ToString(CultureInfo.InvariantCulture), DirectionDepth.One, 1, 1, 1));
+        }
+    }
+
+    [IterationCleanup]
+    public void Cleanup()
+    {
+        _destination.Dispose();
+        _source.Dispose();
+    }
+
+    [Benchmark]
+    public int ImportStates() => _destination.ImportStates(_source);
+}
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+public class StateCollectionBenchmarks
+{
+    private DMIFile _file = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _file = new DMIFile(1, 1);
+        _file.AddState(new DMIState("state", DirectionDepth.One, 1, 1, 1));
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _file.Dispose();
+
+    [Benchmark]
+    public IReadOnlyCollection<DMIState> GetStates() => _file.States;
+}
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+public class StateReadinessBenchmarks
+{
+    private DMIState _state = null!;
+
+    [Params(1, 32)]
+    public int Frames { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _state = new DMIState("state", DirectionDepth.Eight, Frames, 1, 1);
+        for (var direction = 0; direction < _state.Dirs; direction++)
+        {
+            for (var frame = 0; frame < _state.Frames; frame++)
+            {
+                _state.SetFrame(new Image<Rgba32>(1, 1), (StateDirection)direction, frame);
+            }
+        }
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _state.Dispose();
+
+    [Benchmark]
+    public int TotalFrames() => _state.TotalFrames;
+
+    [Benchmark]
+    public int FrameCapacity() => _state.FrameCapacity;
+
+    [Benchmark]
+    public bool IsReadyForSave() => _state.IsReadyForSave();
+}
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+public class StateDisposalBenchmarks
+{
+    private DMIState _state = null!;
+
+    [Params(1, 32)]
+    public int Frames { get; set; }
+
+    [IterationSetup]
+    public void Setup()
+    {
+        _state = new DMIState("state", DirectionDepth.Eight, Frames, 1, 1);
+        for (var direction = 0; direction < _state.Dirs; direction++)
+        {
+            for (var frame = 0; frame < _state.Frames; frame++)
+            {
+                _state.SetFrame(new Image<Rgba32>(1, 1), (StateDirection)direction, frame);
+            }
+        }
+    }
+
+    [Benchmark]
+    public void Dispose() => _state.Dispose();
+}
+
+#pragma warning restore CA1001, CA1024, CA2000

--- a/DMISharp.Tests/DMIModifyTests.cs
+++ b/DMISharp.Tests/DMIModifyTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Linq;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using DMISharp.Metadata;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
 
 namespace DMISharp.Tests;
@@ -64,5 +68,63 @@ public static class DMIModifyTests
         // Assert
         Assert.False(arrowState.IsReadyForSave());
         Assert.False(file.CanSave());
+    }
+
+    [Fact]
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
+    public static void StatesShouldReuseReadOnlyView()
+    {
+        using var file = new DMIFile(1, 1);
+        var view = file.States;
+
+        file.AddState(new DMIState("state", DirectionDepth.One, 1, 1, 1));
+
+        Assert.Same(view, file.States);
+        Assert.Single(view);
+    }
+
+    [Fact]
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
+    public static void ImportStatesShouldPreserveOrderMetadataAndOwnership()
+    {
+        using var destination = new DMIFile(1, 1);
+        using var source = new DMIFile(1, 1);
+        var existing = new DMIState("existing", DirectionDepth.One, 1, 1, 1);
+        var first = new DMIState("first", DirectionDepth.One, 1, 1, 1);
+        var second = new DMIState("second", DirectionDepth.One, 1, 1, 1);
+        first.SetFrame(new Image<Rgba32>(1, 1), 0);
+        destination.AddState(existing);
+        source.AddState(first);
+        source.AddState(second);
+
+        var added = destination.ImportStates(source);
+        source.Dispose();
+
+        Assert.Equal(2, added);
+        Assert.Equal(new[] { existing, first, second }, destination.States);
+        Assert.Equal(destination.States.Select(state => state.Data), destination.Metadata.States);
+        Assert.Empty(source.States);
+        Assert.Empty(source.Metadata.States);
+        Assert.Equal(1, first.TotalFrames);
+    }
+
+    [Fact]
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
+    public static void ImportStatesShouldPreserveUnrelatedMetadata()
+    {
+        using var destination = new DMIFile(1, 1);
+        using var source = new DMIFile(1, 1);
+        var first = new DMIState("first", DirectionDepth.One, 1, 1, 1);
+        var second = new DMIState("second", DirectionDepth.One, 1, 1, 1);
+        var unrelated = new StateMetadata("unrelated");
+        source.AddState(first);
+        source.AddState(second);
+        source.Metadata.States.Insert(0, unrelated);
+        source.Metadata.States.Remove(first.Data);
+
+        destination.ImportStates(source);
+
+        Assert.Equal(new[] { unrelated }, source.Metadata.States);
+        Assert.Equal(new[] { first.Data, second.Data }, destination.Metadata.States);
     }
 }

--- a/DMISharp/DMIFile.cs
+++ b/DMISharp/DMIFile.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -23,6 +24,7 @@ public sealed class DMIFile : IDisposable, IExportable
 {
     private bool _disposedValue;
     private List<DMIState> _states;
+    private ReadOnlyCollection<DMIState> _statesView;
 
     /// <summary>
     /// Constructs a new <see cref="DMIFile"/> for a provided pair of state dimensions.
@@ -33,6 +35,7 @@ public sealed class DMIFile : IDisposable, IExportable
     {
         Metadata = new DMIMetadata(4.0, frameWidth, frameHeight);
         _states = new List<DMIState>();
+        _statesView = _states.AsReadOnly();
     }
 
     /// <summary>
@@ -53,6 +56,7 @@ public sealed class DMIFile : IDisposable, IExportable
         // Reset stream position for processing image data.
         stream.Seek(0, SeekOrigin.Begin);
         _states = GetStates(stream).ToList();
+        _statesView = _states.AsReadOnly();
 
         stream.Dispose();
     }
@@ -74,7 +78,7 @@ public sealed class DMIFile : IDisposable, IExportable
     /// <summary>
     /// All of the <see cref="DMIState"/> entries for this DMI file.
     /// </summary>
-    public IReadOnlyCollection<DMIState> States => _states.AsReadOnly();
+    public IReadOnlyCollection<DMIState> States => _statesView;
 
     /// <summary>
     /// Saves a DMI File to a stream. The resulting file is .dmi-ready
@@ -251,13 +255,16 @@ public sealed class DMIFile : IDisposable, IExportable
     /// <returns>True if the file is ready to be saved, otherwise false</returns>
     public bool CanSave()
     {
-        var result = States.Count != 0;
-        foreach (var state in States)
+        if (_states.Count == 0)
+            return false;
+
+        foreach (var state in _states)
         {
-            result = result && state.IsReadyForSave();
+            if (!state.IsReadyForSave())
+                return false;
         }
 
-        return result;
+        return true;
     }
 
     /// <summary>
@@ -357,6 +364,7 @@ public sealed class DMIFile : IDisposable, IExportable
     public void SortStates()
     {
         _states = _states.OrderBy(x => x.Name).ToList();
+        _statesView = _states.AsReadOnly();
         Metadata.States.Clear();
         foreach (var state in _states)
         {
@@ -371,6 +379,7 @@ public sealed class DMIFile : IDisposable, IExportable
     public void SortStates(IComparer<DMIState> comparer)
     {
         _states = _states.OrderBy(x => x, comparer).ToList();
+        _statesView = _states.AsReadOnly();
         Metadata.States.Clear();
         foreach (var state in _states)
         {
@@ -389,19 +398,76 @@ public sealed class DMIFile : IDisposable, IExportable
             && other.Metadata.FrameHeight == Metadata.FrameHeight
             && other.Metadata.FrameWidth == Metadata.FrameWidth)
         {
-            var added = 0;
-            while (other.States.Count != 0)
+            var added = other._states.Count;
+            if (added == 0)
+                return 0;
+
+            _states.EnsureCapacity(_states.Count + added);
+            Metadata.States.EnsureCapacity(Metadata.States.Count + added);
+            foreach (var state in other._states)
             {
-                var cursor = other.States.First();
-                other.RemoveState(cursor);
-                AddState(cursor);
-                added++;
+                _states.Add(state);
+                Metadata.States.Add(state.Data);
             }
 
+            if (MetadataMatchesStates(other))
+            {
+                other.Metadata.States.Clear();
+            }
+            else
+            {
+                // Preserve RemoveState's behavior if callers have directly altered public metadata.
+                RemoveTransferredMetadata(other);
+            }
+
+            other._states.Clear();
             return added;
         }
 
         return 0;
+    }
+
+    private static bool MetadataMatchesStates(DMIFile file)
+    {
+        if (file.Metadata.States.Count != file._states.Count)
+            return false;
+
+        var comparer = EqualityComparer<StateMetadata>.Default;
+        for (var i = 0; i < file._states.Count; i++)
+        {
+            if (!comparer.Equals(file.Metadata.States[i], file._states[i].Data))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static void RemoveTransferredMetadata(DMIFile file)
+    {
+        var removals = new Dictionary<StateMetadata, int>();
+        foreach (var state in file._states)
+        {
+            removals.TryGetValue(state.Data, out var count);
+            removals[state.Data] = count + 1;
+        }
+
+        var writeIndex = 0;
+        for (var readIndex = 0; readIndex < file.Metadata.States.Count; readIndex++)
+        {
+            var metadata = file.Metadata.States[readIndex];
+            if (removals.TryGetValue(metadata, out var count) && count != 0)
+            {
+                removals[metadata] = count - 1;
+                continue;
+            }
+
+            file.Metadata.States[writeIndex++] = metadata;
+        }
+
+        if (writeIndex != file.Metadata.States.Count)
+        {
+            file.Metadata.States.RemoveRange(writeIndex, file.Metadata.States.Count - writeIndex);
+        }
     }
 
     /// <summary>

--- a/DMISharp/DMIState.cs
+++ b/DMISharp/DMIState.cs
@@ -1,7 +1,6 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
 using DMISharp.Metadata;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Gif;
@@ -173,12 +172,40 @@ public sealed class DMIState : IDisposable
     /// <summary>
     /// The total number of frames in this state.
     /// </summary>
-    public int TotalFrames => _images.Sum(x => x.Count(y => y != null));
+    public int TotalFrames
+    {
+        get
+        {
+            var total = 0;
+            foreach (var direction in _images)
+            {
+                foreach (var image in direction)
+                {
+                    if (image != null)
+                        total = checked(total + 1);
+                }
+            }
+
+            return total;
+        }
+    }
 
     /// <summary>
     /// The total possible number of frames in this state.
     /// </summary>
-    public int FrameCapacity => _images.Sum(x => x.Length);
+    public int FrameCapacity
+    {
+        get
+        {
+            var capacity = 0;
+            foreach (var direction in _images)
+            {
+                capacity = checked(capacity + direction.Length);
+            }
+
+            return capacity;
+        }
+    }
 
     /// <summary>
     /// The direction depth of this state.
@@ -198,9 +225,12 @@ public sealed class DMIState : IDisposable
         if (_disposed)
             return;
 
-        foreach (var image in _images.SelectMany(x => x).Where(x => x != null))
+        foreach (var direction in _images)
         {
-            image!.Dispose();
+            foreach (var image in direction)
+            {
+                image?.Dispose();
+            }
         }
         
         // Empty the array of images to remove all references
@@ -531,7 +561,14 @@ public sealed class DMIState : IDisposable
     public bool IsReadyForSave()
     {
         // check all directions are populated and equal
-        if (TotalFrames != FrameCapacity) return false;
+        foreach (var direction in _images)
+        {
+            foreach (var image in direction)
+            {
+                if (image == null)
+                    return false;
+            }
+        }
 
         // check all required directions are present
         if (_images.Length != (int)DirectionDepth) return false;


### PR DESCRIPTION
## Summary

- make `DMIFile.ImportStates` linear for synchronized state/metadata collections while preserving a linear fallback for caller-desynchronized public metadata
- cache the `States` read-only view and refresh it when sorting replaces the backing list
- replace nested LINQ in frame counts, readiness, and disposal with direct allocation-free traversal
- add focused BenchmarkDotNet coverage and regression tests for ordering, metadata synchronization, ownership transfer, and collection-view behavior

## Import scaling

BenchmarkDotNet 0.13.12, .NET 8.0.28, Windows 11, AMD Ryzen 7 5800X3D.

| States | Baseline | After | Speedup | Baseline allocated | After allocated |
|---:|---:|---:|---:|---:|---:|
| 128 | 41.33 us | 9.784 us | 4.22x | 10.63 KB | 2.44 KB |
| 1,024 | 568.95 us | 68.917 us | 8.26x | 80.77 KB | 16.11 KB |
| 4,096 | 5,936.37 us | 89.377 us | 66.42x | 320.87 KB | 64.44 KB |

The previous repeated first-element removal shifted both lists on every state, producing quadratic growth. The optimized synchronized path appends states/metadata in order and clears the source collections once.

## Collection and readiness benchmarks

| Operation | Frames | Baseline | After | Speedup | Baseline allocated | After allocated |
|---|---:|---:|---:|---:|---:|---:|
| `States` getter | - | 7.690 ns | 1.255 ns | 6.13x | 24 B | 0 B |
| `TotalFrames` | 1 | 195.29 ns | 8.158 ns | 23.94x | 288 B | 0 B |
| `FrameCapacity` | 1 | 38.20 ns | 4.511 ns | 8.47x | 32 B | 0 B |
| `IsReadyForSave` | 1 | 270.76 ns | 9.350 ns | 28.96x | 320 B | 0 B |
| `TotalFrames` | 32 | 1,000.97 ns | 214.829 ns | 4.66x | 288 B | 0 B |
| `FrameCapacity` | 32 | 37.86 ns | 4.626 ns | 8.18x | 32 B | 0 B |
| `IsReadyForSave` | 32 | 1,152.69 ns | 127.063 ns | 9.07x | 320 B | 0 B |

## Behavior guarantees

- destination state and metadata order remain unchanged: existing entries first, imported entries in source order
- imported `DMIState` instances and their exact `StateMetadata` instances are retained rather than copied
- ownership transfers to the destination; disposing the emptied source does not dispose imported frames
- source states and their matching metadata entries are removed
- if public metadata was manually desynchronized, unrelated entries and original ordering are preserved while matching transferred entries are removed with `List.Remove`-equivalent multiplicity
- `States` keeps its existing `IReadOnlyCollection<DMIState>` public API and remains a live read-only view

## Disposal caveat

| Frames | Baseline | After | Baseline allocated | After allocated |
|---:|---:|---:|---:|---:|
| 1 | 10.78 us | 7.239 us | 1.10 KB | 1.31 KB |
| 32 | 123.60 us | 105.304 us | 11.07 KB | 10.67 KB |

Disposal time improves, but ImageSharp resource cleanup dominates this benchmark. The single-frame managed-allocation reading is noisy and increases by 0.21 KB despite removal of LINQ iterator allocations; the 32-frame case decreases by 0.40 KB.

## Validation

- 28/28 tests pass on net6.0
- 28/28 tests pass on net7.0
- 28/28 tests pass on net8.0

The machine only has newer runtimes installed, so net6.0/net7.0 test execution used `DOTNET_ROLL_FORWARD=Major`.