### PR TITLE
Optimize GIF frame construction

### DIFF
--- a/DMISharp.Benchmark/OptimizationBenchmarks.cs
+++ b/DMISharp.Benchmark/OptimizationBenchmarks.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace DMISharp.Benchmark;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+[SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable",
+    Justification = "BenchmarkDotNet invokes GlobalCleanup after benchmark execution.")]
+public class GifConstructionBenchmarks
+{
+    private DMIFile _tinyAnimationFile = null!;
+    private DMIFile _largeAnimationFile = null!;
+    private DMIState _tinyAnimation = null!;
+    private DMIState _largeAnimation = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _tinyAnimationFile = new DMIFile(@"Data/Input/animal.dmi");
+        _tinyAnimation = _tinyAnimationFile.States.First(x => x.Name == "mushroom");
+        _largeAnimationFile = new DMIFile(@"Data/Input/352x352.dmi");
+        _largeAnimation = _largeAnimationFile.States.First(x => x.Name == "singularity_s11");
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _tinyAnimationFile.Dispose();
+        _largeAnimationFile.Dispose();
+    }
+
+    [Benchmark]
+    public void ConstructTinyAnimation()
+    {
+        using var image = _tinyAnimation.GetAnimated(StateDirection.South);
+    }
+
+    [Benchmark]
+    public void ConstructLargeAnimation()
+    {
+        using var image = _largeAnimation.GetAnimated(StateDirection.South);
+    }
+}

--- a/DMISharp.Tests/DMIAnimationTests.cs
+++ b/DMISharp.Tests/DMIAnimationTests.cs
@@ -1,0 +1,78 @@
+using System;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Gif;
+using SixLabors.ImageSharp.PixelFormats;
+using Xunit;
+
+namespace DMISharp.Tests;
+
+public sealed class DMIAnimationTests
+{
+    [Fact]
+    public void GetAnimatedCopiesFramesAndMetadataWithoutMutatingSources()
+    {
+        using var state = new DMIState("animated", DirectionDepth.One, 2, 3, 1);
+#pragma warning disable CA2000
+        var first = new Image<Rgba32>(3, 1);
+#pragma warning restore CA2000
+        first[0, 0] = new Rgba32(10, 20, 30, 0);
+        first[1, 0] = new Rgba32(40, 50, 60, 128);
+        first[2, 0] = new Rgba32(70, 80, 90, 255);
+        var second = first.Clone();
+
+        var firstSourceMetadata = first.Frames.RootFrame.Metadata.GetFormatMetadata(GifFormat.Instance);
+        firstSourceMetadata.FrameDelay = 99;
+        firstSourceMetadata.DisposalMethod = GifDisposalMethod.NotDispose;
+        var secondSourceMetadata = second.Frames.RootFrame.Metadata.GetFormatMetadata(GifFormat.Instance);
+        secondSourceMetadata.FrameDelay = 98;
+        secondSourceMetadata.DisposalMethod = GifDisposalMethod.RestoreToPrevious;
+
+        state.SetFrame(first, 0);
+        state.SetFrame(second, 1);
+        state.SetDelay(new[] { 1.5, 2.5 });
+        state.SetLoop(3);
+
+        using var animation = state.GetAnimated(StateDirection.South);
+
+        Assert.Equal(2, animation.Frames.Count);
+        Assert.Equal(default, animation.Frames[0][0, 0]);
+        Assert.Equal(new Rgba32(40, 50, 60, 128), animation.Frames[0][1, 0]);
+        Assert.Equal(new Rgba32(70, 80, 90, 255), animation.Frames[0][2, 0]);
+
+        var gifMetadata = animation.Metadata.GetFormatMetadata(GifFormat.Instance);
+        Assert.Equal(GifColorTableMode.Local, gifMetadata.ColorTableMode);
+        Assert.Equal(3, gifMetadata.RepeatCount);
+        Assert.Equal(15, animation.Frames[0].Metadata.GetFormatMetadata(GifFormat.Instance).FrameDelay);
+        Assert.Equal(25, animation.Frames[1].Metadata.GetFormatMetadata(GifFormat.Instance).FrameDelay);
+        foreach (var frame in animation.Frames)
+        {
+            Assert.Equal(GifDisposalMethod.RestoreToBackground,
+                frame.Metadata.GetFormatMetadata(GifFormat.Instance).DisposalMethod);
+        }
+
+        Assert.Equal(new Rgba32(10, 20, 30, 0), first[0, 0]);
+        Assert.Equal(99, firstSourceMetadata.FrameDelay);
+        Assert.Equal(GifDisposalMethod.NotDispose, firstSourceMetadata.DisposalMethod);
+        Assert.Equal(98, secondSourceMetadata.FrameDelay);
+        Assert.Equal(GifDisposalMethod.RestoreToPrevious, secondSourceMetadata.DisposalMethod);
+    }
+
+    [Fact]
+    public void GetAnimatedMissingFrameDoesNotMutateEarlierFrames()
+    {
+        using var state = new DMIState("incomplete", DirectionDepth.One, 2, 1, 1);
+#pragma warning disable CA2000
+        var first = new Image<Rgba32>(1, 1, new Rgba32(10, 20, 30, 0));
+#pragma warning restore CA2000
+        var sourceMetadata = first.Frames.RootFrame.Metadata.GetFormatMetadata(GifFormat.Instance);
+        sourceMetadata.FrameDelay = 99;
+        sourceMetadata.DisposalMethod = GifDisposalMethod.NotDispose;
+        state.SetFrame(first, 0);
+        state.InitializeDelay();
+
+        Assert.Throws<InvalidOperationException>(() => state.GetAnimated(StateDirection.South));
+        Assert.Equal(new Rgba32(10, 20, 30, 0), first[0, 0]);
+        Assert.Equal(99, sourceMetadata.FrameDelay);
+        Assert.Equal(GifDisposalMethod.NotDispose, sourceMetadata.DisposalMethod);
+    }
+}

--- a/DMISharp/DMIState.cs
+++ b/DMISharp/DMIState.cs
@@ -6,7 +6,6 @@ using DMISharp.Metadata;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Gif;
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Quantization;
 
 namespace DMISharp;
@@ -326,31 +325,54 @@ public sealed class DMIState : IDisposable
 
         // Develop gif
         var toReturn = new Image<Rgba32>(Width, Height);
-        for (var frame = 0; frame < Frames; frame++)
+        try
         {
-            var cursor = _images[(int)direction][frame];
-            if (cursor != null)
+            for (var frame = 0; frame < Frames; frame++)
             {
-                var metadata = cursor.Frames.RootFrame.Metadata.GetFormatMetadata(GifFormat.Instance);
+                var cursor = _images[(int)direction][frame];
+                if (cursor == null)
+                {
+                    throw new InvalidOperationException(
+                        $"Image data missing frame for direction {direction}, cannot animate");
+                }
+
+                var outputFrame = toReturn.Frames.AddFrame(cursor.Frames.RootFrame);
+                var metadata = outputFrame.Metadata.GetFormatMetadata(GifFormat.Instance);
                 metadata.FrameDelay = (int)(Data.Delay![frame] * 10.0); // GIF frames are 10ms compared to 100ms tick
-                metadata.DisposalMethod = GifDisposalMethod.RestoreToBackground; // Ensures transparent pixels 
-                toReturn.Frames.InsertFrame(frame, cursor.Frames.RootFrame);
+                metadata.DisposalMethod = GifDisposalMethod.RestoreToBackground; // Ensures transparent pixels
+                ClearTransparentPixels(outputFrame);
             }
-            else
-                throw new InvalidOperationException(
-                    $"Image data missing frame for direction {direction}, cannot animate");
+
+            toReturn.Frames.RemoveFrame(0);
+            var gifMetadata = toReturn.Metadata.GetFormatMetadata(GifFormat.Instance);
+            gifMetadata.ColorTableMode = GifColorTableMode.Local;
+            gifMetadata.RepeatCount = (ushort)Data.Loop;
+
+            return toReturn;
         }
+        catch
+        {
+            toReturn.Dispose();
+            throw;
+        }
+    }
 
-        // Final process
-        var gifMetadata = toReturn.Metadata.GetFormatMetadata(GifFormat.Instance);
-        gifMetadata.ColorTableMode = GifColorTableMode.Local;
-        toReturn.Frames.RemoveFrame(toReturn.Frames.Count - 1); // Remove empty frame at end of the animation
-        toReturn.Mutate(x =>
-            x.BackgroundColor(
-                new Rgba32())); // Specify the animation has a transparent background for transparent pixels
-        gifMetadata.RepeatCount = (ushort)Data.Loop;
-
-        return toReturn;
+    private static void ClearTransparentPixels(ImageFrame<Rgba32> frame)
+    {
+        frame.ProcessPixelRows(static accessor =>
+        {
+            for (var y = 0; y < accessor.Height; y++)
+            {
+                var row = accessor.GetRowSpan(y);
+                for (var x = 0; x < row.Length; x++)
+                {
+                    if (row[x].A == 0)
+                    {
+                        row[x] = default;
+                    }
+                }
+            }
+        });
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- append cloned animation frames instead of index-inserting them
- set frame delay and disposal metadata on output clones rather than mutating source frames
- replace the full-image transparent background processor with an equivalent zero-alpha RGB clear pass
- dispose partially constructed output when frame construction fails
- add focused BenchmarkDotNet coverage and correctness tests

## Benchmarks

BenchmarkDotNet 0.13.12 on .NET 8.0.28, AMD Ryzen 7 5800X3D:

| Animation | Baseline | Optimized | Improvement | Allocated before | Allocated after | Reduction |
|---|---:|---:|---:|---:|---:|---:|
| Tiny: `mushroom`, 3 x 32x32 frames | 31.44 us | 5.590 us | 82.22% | 14.13 KB | 3.4 KB | 75.94% |
| Large: `singularity_s11`, 16 x 352x352 frames | 2,364.19 us | 1,917.336 us | 18.90% | 605.23 KB | 13.45 KB | 97.78% |

## Correctness

- legacy and optimized encoded GIF bytes are identical for both benchmark fixtures
- transparent pixels retain the previous behavior: RGB channels are cleared only when alpha is zero
- frame delays, disposal mode, color table mode, and repeat count remain unchanged
- source frame pixels and GIF metadata are no longer mutated while constructing an animation
- missing-frame failures leave earlier source frames unchanged and release partial output

## Tradeoffs

ImageSharp requires every public `Image<TPixel>` constructor to create or receive a root frame, and its public frame insertion APIs clone input frames. This keeps the temporary blank root frame, appends clones in order, then removes the root once. Eliminating root creation would require relying on non-public ownership APIs. The explicit transparent-pixel loop is narrower and substantially cheaper than the general-purpose `BackgroundColor` processor while preserving its behavior for a transparent background.

## Validation

All 27 tests pass on each of `net6.0`, `net7.0`, and `net8.0` (81 target-specific test runs).