### PR TITLE
Optimize palette color lookup

### DIFF
--- a/DMISharp.Benchmark/DMIBenchmarks.cs
+++ b/DMISharp.Benchmark/DMIBenchmarks.cs
@@ -31,10 +31,12 @@ public class DMIBenchmarks
     public DMIFile ReadLargeDMIFile() => new("Data/Input/large.dmi");
 
     [Benchmark]
-    public void WriteDMIFile()
+    [Arguments("small.dmi")]
+    [Arguments("air_meter.dmi")]
+    public void WritePaletteDMIFile(string fileName)
     {
         using var ms = new MemoryStream();
-        using var file = new DMIFile(@"Data/Input/air_meter.dmi");
+        using var file = new DMIFile(Path.Combine("Data", "Input", fileName));
         file.Save(ms);
     }
 

--- a/DMISharp/Quantization/NoFrillsQuantizer.cs
+++ b/DMISharp/Quantization/NoFrillsQuantizer.cs
@@ -66,10 +66,9 @@ internal readonly struct NoFrillsQuantizer<TPixel> : IQuantizer<TPixel>
 
     public byte GetQuantizedColor(TPixel color, out TPixel match)
     {
-        if (!_paletteLookup.ContainsKey(color))
+        if (!_paletteLookup.TryGetValue(color, out var paletteIdx))
             throw new ArgumentException("Unknown or invalid color for existing palette");
 
-        var paletteIdx = _paletteLookup[color];
         match = Palette.Span[paletteIdx];
         return (byte)paletteIdx;
     }


### PR DESCRIPTION
## Summary
- replace `ContainsKey` plus dictionary indexing with one `TryGetValue` in `NoFrillsQuantizer<TPixel>.GetQuantizedColor`
- preserve the existing unknown-color exception and palette match behavior
- extend the save benchmark to cover both `small.dmi` and `air_meter.dmi`

This is a low-risk micro-optimization that removes a redundant dictionary probe. Its end-to-end impact depends on how much of a save workload is spent in palette lookup.

## Benchmark results
Prior .NET 8 evidence showed:

| Workload | Time | Allocations |
| --- | ---: | ---: |
| `small.dmi` | +0.52% (neutral/noise) | unchanged |
| `air_meter.dmi` | -7.60% | unchanged |

An independent sequential BenchmarkDotNet rerun in this worktree (15 measured iterations, 5 warmups) produced `air_meter.dmi` 2.389 ms → 2.385 ms (-0.17%) and `small.dmi` 4.496 ms → 4.689 ms (+4.29%), with effectively unchanged allocations (~96.87 KB and ~89 KB respectively). The differing end-to-end timings reinforce that whole-save results are workload- and environment-dependent; the deterministic improvement is reducing successful palette lookups from two dictionary probes to one.

## Tests
- `dotnet test DMISharp.Tests/DMISharp.Tests.csproj --framework net8.0 --configuration Release` (25 passed)