### PR TITLE
Optimize DMI loading allocations

### DIFF
--- a/DMISharp.Benchmark/DMIBenchmarks.cs
+++ b/DMISharp.Benchmark/DMIBenchmarks.cs
@@ -8,6 +8,51 @@ using BenchmarkDotNet.Jobs;
 
 namespace DMISharp.Benchmark;
 
+[MemoryDiagnoser, Config(typeof(DMIReadBenchmarkConfig))]
+public class DMIReadBenchmarks
+{
+    private string _path = null!;
+
+    [Params("small.dmi", "large.dmi", "352x352.dmi")]
+    public string FileName { get; set; } = null!;
+
+    [GlobalSetup]
+    public void Setup() => _path = Path.Combine("Data", "Input", FileName);
+
+    [Benchmark]
+    public void ReadDMIFile()
+    {
+        using var file = new DMIFile(_path);
+    }
+
+    [Benchmark]
+    public void ReadAndMaterializeAllFrames()
+    {
+        using var file = new DMIFile(_path);
+        foreach (var state in file.States)
+        {
+            for (var frame = 0; frame < state.Frames; frame++)
+            {
+                for (var direction = 0; direction < state.Dirs; direction++)
+                {
+                    _ = state.GetFrame((StateDirection)direction, frame);
+                }
+            }
+        }
+    }
+}
+
+internal sealed class DMIReadBenchmarkConfig : ManualConfig
+{
+    public DMIReadBenchmarkConfig()
+    {
+        var baseJob = Job.Default.WithRuntime(CoreRuntime.Core80);
+
+        AddJob(baseJob.WithNuGet("DMISharp", "2.0.2").AsBaseline());
+        AddJob(baseJob);
+    }
+}
+
 [MemoryDiagnoser, Config(typeof(DMIBenchmarkConfig))]
 [SuppressMessage("Performance", "CA1822:Mark members as static")]
 public class DMIBenchmarks

--- a/DMISharp.Tests/DMIReadTests.cs
+++ b/DMISharp.Tests/DMIReadTests.cs
@@ -1,4 +1,8 @@
+using System;
+using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
+using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
 
 namespace DMISharp.Tests;
@@ -68,5 +72,109 @@ public class DMIReadTests
     {
         using var file = new DMIFile(@"Data/Input/turf_analysis_goon.dmi");
         Assert.Equal(16, file.States.Count);
+    }
+
+    [Fact]
+    public void CanReadFromNonSeekableStream()
+    {
+        var stream = new NonSeekableReadStream(File.OpenRead(@"Data/Input/animal.dmi"));
+
+        using var file = new DMIFile(stream);
+
+        Assert.Equal(154, file.States.Count);
+        Assert.True(stream.IsDisposed);
+        Assert.NotNull(file.States.First().GetFrame(0));
+    }
+
+    [Fact]
+    public void LoadedFramesRemainIndependentlyMutable()
+    {
+        using var file = new DMIFile(@"Data/Input/animal.dmi");
+        var state = file.States.First(x => x.Name == "mushroom");
+        var first = state.GetFrame(StateDirection.South, 0)!;
+        var second = state.GetFrame(StateDirection.North, 0)!;
+        var secondPixel = second[0, 0];
+        var replacement = new Rgba32(1, 2, 3, 4);
+
+        first[0, 0] = replacement;
+
+        Assert.Equal(replacement, first[0, 0]);
+        Assert.Equal(secondPixel, second[0, 0]);
+        Assert.Same(first, state.GetFrame(StateDirection.South, 0));
+    }
+
+    [Fact]
+    public void RemovedStateRetainsUnmaterializedFrames()
+    {
+        DMIState state;
+        using (var file = new DMIFile(@"Data/Input/turf_analysis.dmi"))
+        {
+            state = file.States.Last();
+            Assert.True(file.RemoveState(state));
+        }
+
+        using (state)
+        {
+            Assert.NotNull(state.GetFrame(0));
+        }
+    }
+
+    [Fact]
+    public void ConcurrentFrameReadsReturnSameOwnedImage()
+    {
+        using var file = new DMIFile(@"Data/Input/animal.dmi");
+        var state = file.States.First(x => x.Name == "mushroom");
+        var frames = new object[64];
+
+        Parallel.For(0, frames.Length, i => frames[i] = state.GetFrame(StateDirection.South, 0)!);
+
+        Assert.All(frames, frame => Assert.Same(frames[0], frame));
+    }
+
+    private sealed class NonSeekableReadStream : Stream
+    {
+        private readonly Stream _inner;
+
+        public NonSeekableReadStream(Stream inner)
+        {
+            _inner = inner;
+        }
+
+        public bool IsDisposed { get; private set; }
+
+        public override bool CanRead => _inner.CanRead;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => _inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+                IsDisposed = true;
+            }
+
+            base.Dispose(disposing);
+        }
     }
 }

--- a/DMISharp/DMIFile.cs
+++ b/DMISharp/DMIFile.cs
@@ -47,12 +47,9 @@ public sealed class DMIFile : IDisposable, IExportable
             throw new ArgumentNullException(nameof(stream));
         }
 
-        // As the metadata is embedded in the PNG file, extract into a usable object.
-        Metadata = new DMIMetadata(stream);
-
-        // Reset stream position for processing image data.
-        stream.Seek(0, SeekOrigin.Begin);
-        _states = GetStates(stream).ToList();
+        using var atlas = new DMIImageAtlas(Image.Load<Rgba32>(stream));
+        Metadata = new DMIMetadata(atlas.TextData);
+        _states = GetStates(atlas);
 
         stream.Dispose();
     }
@@ -303,13 +300,12 @@ public sealed class DMIFile : IDisposable, IExportable
     /// <summary>
     /// Processes DMI metadata into DMI State objects.
     /// </summary>
-    /// <param name="source">The stream containing the DMI file data.</param>
-    /// <returns>An enumerable collection of DMI State objects representing the states of the DMI File.</returns>
-    private IEnumerable<DMIState> GetStates(Stream source)
+    /// <param name="atlas">The decoded DMI atlas.</param>
+    /// <returns>A collection of DMI State objects representing the states of the DMI File.</returns>
+    private List<DMIState> GetStates(DMIImageAtlas atlas)
     {
         var states = new List<DMIState>();
 
-        using var img = Image.Load<Rgba32>(source);
         // DMI data did not include widths or heights, assume that it is then
         // perfect squares, thus we will determine the w/h programatically...
         if (Metadata.FrameWidth == -1 || Metadata.FrameHeight == -1)
@@ -318,10 +314,10 @@ public sealed class DMIFile : IDisposable, IExportable
 
             for (var rows = 1; totalFrames >= rows; rows++)
             {
-                if (img.Width / (totalFrames / rows) == img.Height / rows)
+                if (atlas.Width / (totalFrames / rows) == atlas.Height / rows)
                 {
-                    Metadata.FrameHeight = img.Height / rows;
-                    Metadata.FrameWidth = img.Width / (totalFrames / rows);
+                    Metadata.FrameHeight = atlas.Height / rows;
+                    Metadata.FrameWidth = atlas.Width / (totalFrames / rows);
                     break;
                 }
             }
@@ -332,20 +328,28 @@ public sealed class DMIFile : IDisposable, IExportable
             return states;
         }
 
-        var wFrames = img.Width / Metadata.FrameWidth;
-        var hFrames = img.Height / Metadata.FrameHeight;
+        var wFrames = atlas.Width / Metadata.FrameWidth;
+        var hFrames = atlas.Height / Metadata.FrameHeight;
         var processedImages = 0;
-        var currWIndex = 0;
-        var currHIndex = 0;
 
-        foreach (var state in Metadata.States)
+        try
         {
-            var toAdd = new DMIState(state, img, currWIndex, wFrames, currHIndex, hFrames, Metadata.FrameWidth,
-                Metadata.FrameHeight);
-            processedImages += toAdd.TotalFrames;
-            currHIndex = processedImages / wFrames;
-            currWIndex = processedImages % wFrames;
-            states.Add(toAdd);
+            foreach (var state in Metadata.States)
+            {
+                var toAdd = new DMIState(state, atlas, processedImages, wFrames, hFrames, Metadata.FrameWidth,
+                    Metadata.FrameHeight);
+                processedImages += toAdd.TotalFrames;
+                states.Add(toAdd);
+            }
+        }
+        catch
+        {
+            foreach (var state in states)
+            {
+                state.Dispose();
+            }
+
+            throw;
         }
 
         return states;

--- a/DMISharp/DMIImageAtlas.cs
+++ b/DMISharp/DMIImageAtlas.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Formats.Png.Chunks;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace DMISharp;
+
+internal sealed class DMIImageAtlas : IDisposable
+{
+    private readonly object _imageLock = new();
+    private Image<Rgba32>? _image;
+    private int _referenceCount = 1;
+
+    public DMIImageAtlas(Image<Rgba32> image)
+    {
+        _image = image ?? throw new ArgumentNullException(nameof(image));
+    }
+
+    public int Width => GetImage().Width;
+
+    public int Height => GetImage().Height;
+
+    public IEnumerable<PngTextData> TextData =>
+        GetImage().Metadata.GetFormatMetadata(PngFormat.Instance).TextData;
+
+    public DMIImageAtlas AddReference()
+    {
+        while (true)
+        {
+            var referenceCount = Volatile.Read(ref _referenceCount);
+            if (referenceCount == 0)
+            {
+                throw new ObjectDisposedException(nameof(DMIImageAtlas));
+            }
+
+            if (Interlocked.CompareExchange(ref _referenceCount, referenceCount + 1, referenceCount) ==
+                referenceCount)
+            {
+                return this;
+            }
+        }
+    }
+
+    public Image<Rgba32> ExtractFrame(int sourceIndex, int framesPerRow, int width, int height)
+    {
+        var frame = new Image<Rgba32>(width, height);
+        var xOffset = sourceIndex % framesPerRow * width;
+        var yOffset = sourceIndex / framesPerRow * height;
+
+        try
+        {
+            lock (_imageLock)
+            {
+                GetImage().ProcessPixelRows(frame, (sourceAccessor, frameAccessor) =>
+                {
+                    for (var y = 0; y < height; y++)
+                    {
+                        sourceAccessor.GetRowSpan(y + yOffset)
+                            .Slice(xOffset, width)
+                            .CopyTo(frameAccessor.GetRowSpan(y));
+                    }
+                });
+            }
+
+            return frame;
+        }
+        catch
+        {
+            frame.Dispose();
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Decrement(ref _referenceCount) != 0)
+        {
+            return;
+        }
+
+        lock (_imageLock)
+        {
+            _image?.Dispose();
+            _image = null;
+        }
+    }
+
+    private Image<Rgba32> GetImage() =>
+        _image ?? throw new ObjectDisposedException(nameof(DMIImageAtlas));
+}

--- a/DMISharp/DMIState.cs
+++ b/DMISharp/DMIState.cs
@@ -86,6 +86,11 @@ public enum DirectionDepth
 public sealed class DMIState : IDisposable
 {
     private Image<Rgba32>?[][] _images; // Stores each frame image following the [direction][frame] pattern.
+    private int[][] _atlasIndices;
+    private DMIImageAtlas? _atlas;
+    private int _atlasFramesPerRow;
+    private int _unmaterializedFrameCount;
+    private readonly object _materializationLock = new();
     private bool _disposed;
     
     /// <summary>
@@ -101,12 +106,14 @@ public sealed class DMIState : IDisposable
         Data = new StateMetadata(name, directionDepth, frames);
         DirectionDepth = directionDepth;
         _images = new Image<Rgba32>[(int)directionDepth][];
+        _atlasIndices = new int[(int)directionDepth][];
         Width = frameWidth;
         Height = frameHeight;
 
         for (var dir = 0; dir < Dirs; dir++)
         {
             _images[dir] = new Image<Rgba32>[Frames];
+            _atlasIndices[dir] = CreateEmptyAtlasIndices(Frames);
         }
     }
 
@@ -136,9 +143,48 @@ public sealed class DMIState : IDisposable
 
         // Develop frames
         _images = SeperateImages(source, currWIndex, wIndex, currHIndex, hIndex, width, height);
+        _atlasIndices = new int[Dirs][];
+        for (var dir = 0; dir < Dirs; dir++)
+        {
+            _atlasIndices[dir] = CreateEmptyAtlasIndices(Frames);
+        }
 
         // Set directionality
         DirectionDepth = (DirectionDepth)_images.Length;
+    }
+
+    internal DMIState(StateMetadata state, DMIImageAtlas atlas, int startIndex, int wIndex, int hIndex, int width,
+        int height)
+    {
+        Data = state ?? throw new ArgumentNullException(nameof(state));
+        Height = height;
+        Width = width;
+        DirectionDepth = (DirectionDepth)Dirs;
+        _images = new Image<Rgba32>[Dirs][];
+        _atlasIndices = new int[Dirs][];
+        _atlasFramesPerRow = wIndex;
+
+        var atlasCapacity = wIndex * hIndex;
+        var sourceIndex = startIndex;
+        for (var dir = 0; dir < Dirs; dir++)
+        {
+            _images[dir] = new Image<Rgba32>[Frames];
+            _atlasIndices[dir] = CreateEmptyAtlasIndices(Frames);
+        }
+
+        for (var frame = 0; frame < Frames; frame++)
+        {
+            for (var dir = 0; dir < Dirs && sourceIndex < atlasCapacity; dir++, sourceIndex++)
+            {
+                _atlasIndices[dir][frame] = sourceIndex;
+                _unmaterializedFrameCount++;
+            }
+        }
+
+        if (_unmaterializedFrameCount > 0)
+        {
+            _atlas = atlas.AddReference();
+        }
     }
 
     /// <summary>
@@ -173,7 +219,25 @@ public sealed class DMIState : IDisposable
     /// <summary>
     /// The total number of frames in this state.
     /// </summary>
-    public int TotalFrames => _images.Sum(x => x.Count(y => y != null));
+    public int TotalFrames
+    {
+        get
+        {
+            var total = 0;
+            for (var direction = 0; direction < _images.Length; direction++)
+            {
+                for (var frame = 0; frame < _images[direction].Length; frame++)
+                {
+                    if (_images[direction][frame] != null || _atlasIndices[direction][frame] >= 0)
+                    {
+                        total++;
+                    }
+                }
+            }
+
+            return total;
+        }
+    }
 
     /// <summary>
     /// The total possible number of frames in this state.
@@ -195,18 +259,25 @@ public sealed class DMIState : IDisposable
     /// </summary>
     public void Dispose()
     {
-        if (_disposed)
-            return;
-
-        foreach (var image in _images.SelectMany(x => x).Where(x => x != null))
+        lock (_materializationLock)
         {
-            image!.Dispose();
+            if (_disposed)
+                return;
+
+            foreach (var image in _images.SelectMany(x => x).Where(x => x != null))
+            {
+                image!.Dispose();
+            }
+        
+            // Empty the array of images to remove all references
+            _images = Array.Empty<Image<Rgba32>[]>();
+            _atlasIndices = Array.Empty<int[]>();
+            _atlas?.Dispose();
+            _atlas = null;
+            _unmaterializedFrameCount = 0;
+        
+            _disposed = true;
         }
-        
-        // Empty the array of images to remove all references
-        _images = Array.Empty<Image<Rgba32>[]>();
-        
-        _disposed = true;
     }
 
     /// <summary>
@@ -328,7 +399,7 @@ public sealed class DMIState : IDisposable
         var toReturn = new Image<Rgba32>(Width, Height);
         for (var frame = 0; frame < Frames; frame++)
         {
-            var cursor = _images[(int)direction][frame];
+            var cursor = GetFrame(direction, frame);
             if (cursor != null)
             {
                 var metadata = cursor.Frames.RootFrame.Metadata.GetFormatMetadata(GifFormat.Instance);
@@ -383,7 +454,32 @@ public sealed class DMIState : IDisposable
     /// <param name="direction">The direction of the frame</param>
     /// <param name="frame">The frame index</param>
     /// <returns>An ImageSharp Image representing the frame</returns>
-    public Image<Rgba32>? GetFrame(StateDirection direction, int frame) => _images[(int)direction][frame];
+    public Image<Rgba32>? GetFrame(StateDirection direction, int frame)
+    {
+        var directionIndex = (int)direction;
+        var image = _images[directionIndex][frame];
+        var sourceIndex = _atlasIndices[directionIndex][frame];
+        if (image != null || sourceIndex < 0)
+        {
+            return image;
+        }
+
+        lock (_materializationLock)
+        {
+            image = _images[directionIndex][frame];
+            sourceIndex = _atlasIndices[directionIndex][frame];
+            if (image != null || sourceIndex < 0)
+            {
+                return image;
+            }
+
+            image = _atlas!.ExtractFrame(sourceIndex, _atlasFramesPerRow, Width, Height);
+            _images[directionIndex][frame] = image;
+            _atlasIndices[directionIndex][frame] = -1;
+            ReleaseMaterializedAtlasFrame();
+            return image;
+        }
+    }
 
     /// <summary>
     /// Helper for frame retrieval, defaults to the North (1) direction
@@ -400,20 +496,24 @@ public sealed class DMIState : IDisposable
     /// <param name="frame">The frame index</param>
     public void SetFrame(Image<Rgba32> newFrame, StateDirection direction, int frame)
     {
-        if (newFrame != null && (newFrame.Width != Width || newFrame.Height != Height))
+        lock (_materializationLock)
         {
-            throw new ArgumentException(
-                "Cannot insert a frame that is different than the size of the state's frame size.");
-        }
+            if (newFrame != null && (newFrame.Width != Width || newFrame.Height != Height))
+            {
+                throw new ArgumentException(
+                    "Cannot insert a frame that is different than the size of the state's frame size.");
+            }
 
-        // Delete old frame if necessary
-        var cursor = _images[(int)direction][frame];
-        if (cursor != null && cursor != newFrame)
-        {
-            cursor.Dispose();
-        }
+            // Delete old frame if necessary
+            var cursor = _images[(int)direction][frame];
+            if (cursor != null && cursor != newFrame)
+            {
+                cursor.Dispose();
+            }
 
-        _images[(int)direction][frame] = newFrame;
+            ReleaseAtlasFrame(direction, frame);
+            _images[(int)direction][frame] = newFrame;
+        }
     }
 
     /// <summary>
@@ -433,9 +533,13 @@ public sealed class DMIState : IDisposable
     /// <param name="frame">The frame index</param>
     public void DeleteFrame(StateDirection direction, int frame)
     {
-        // Ensure image is disposed
-        _images[(int)direction][frame]?.Dispose();
-        _images[(int)direction][frame] = null;
+        lock (_materializationLock)
+        {
+            // Ensure image is disposed
+            _images[(int)direction][frame]?.Dispose();
+            _images[(int)direction][frame] = null;
+            ReleaseAtlasFrame(direction, frame);
+        }
     }
 
     /// <summary>
@@ -453,41 +557,49 @@ public sealed class DMIState : IDisposable
     /// <param name="depth">The new directional depth for the state</param>
     public void SetDirectionDepth(DirectionDepth depth)
     {
-        if (depth == DirectionDepth)
-            return;
-
-        var minDepth = Math.Min((int)depth, (int)DirectionDepth);
-        var temp = new Image<Rgba32>?[(int)depth][];
-        for (var i = 0; i < minDepth; i++)
+        lock (_materializationLock)
         {
-            temp[i] = _images[i];
-        }
+            if (depth == DirectionDepth)
+                return;
 
-        // Dispose of images outside of our new dirs
-        if (depth < DirectionDepth)
-        {
-            for (var i = (int)depth; i < (int)DirectionDepth; i++)
+            var minDepth = Math.Min((int)depth, (int)DirectionDepth);
+            var temp = new Image<Rgba32>?[(int)depth][];
+            var tempAtlasIndices = new int[(int)depth][];
+            for (var i = 0; i < minDepth; i++)
             {
-                for (var j = 0; j < Frames; j++)
+                temp[i] = _images[i];
+                tempAtlasIndices[i] = _atlasIndices[i];
+            }
+
+            // Dispose of images outside of our new dirs
+            if (depth < DirectionDepth)
+            {
+                for (var i = (int)depth; i < (int)DirectionDepth; i++)
                 {
-                    var cursor = _images[i][j];
-                    cursor?.Dispose();
+                    for (var j = 0; j < Frames; j++)
+                    {
+                        var cursor = _images[i][j];
+                        cursor?.Dispose();
+                        ReleaseAtlasFrame((StateDirection)i, j);
+                    }
                 }
             }
-        }
 
-        // Insert empty arrays for extra new dirs if available
-        if (depth > DirectionDepth)
-        {
-            for (var i = (int)DirectionDepth; i < (int)depth; i++)
+            // Insert empty arrays for extra new dirs if available
+            if (depth > DirectionDepth)
             {
-                temp[i] = new Image<Rgba32>[Frames];
+                for (var i = (int)DirectionDepth; i < (int)depth; i++)
+                {
+                    temp[i] = new Image<Rgba32>[Frames];
+                    tempAtlasIndices[i] = CreateEmptyAtlasIndices(Frames);
+                }
             }
-        }
 
-        _images = temp;
-        DirectionDepth = depth;
-        Data.Dirs = (int)depth;
+            _images = temp;
+            _atlasIndices = tempAtlasIndices;
+            DirectionDepth = depth;
+            Data.Dirs = (int)depth;
+        }
     }
 
     /// <summary>
@@ -496,32 +608,70 @@ public sealed class DMIState : IDisposable
     /// <param name="frames">The new frame depth of the state</param>
     public void SetFrameCount(int frames)
     {
-        if (Frames == frames)
-            return;
-
-        var temp = new Image<Rgba32>?[Dirs][];
-        var minFrames = Math.Min(Frames, frames);
-
-        for (var dir = 0; dir < Dirs; dir++)
+        lock (_materializationLock)
         {
-            temp[dir] = new Image<Rgba32>?[frames];
-            for (var i = 0; i < minFrames; i++)
+            if (Frames == frames)
+                return;
+
+            var temp = new Image<Rgba32>?[Dirs][];
+            var tempAtlasIndices = new int[Dirs][];
+            var minFrames = Math.Min(Frames, frames);
+
+            for (var dir = 0; dir < Dirs; dir++)
             {
-                temp[dir][i] = _images[dir][i];
+                temp[dir] = new Image<Rgba32>?[frames];
+                tempAtlasIndices[dir] = CreateEmptyAtlasIndices(frames);
+                for (var i = 0; i < minFrames; i++)
+                {
+                    temp[dir][i] = _images[dir][i];
+                    tempAtlasIndices[dir][i] = _atlasIndices[dir][i];
+                }
+
+                // Dispose of frames that we are no longer tracking ("lost" frames)
+                if (frames >= Frames)
+                    continue;
+
+                for (var i = minFrames; i < Frames; i++)
+                {
+                    _images[dir][i]?.Dispose();
+                    ReleaseAtlasFrame((StateDirection)dir, i);
+                }
             }
 
-            // Dispose of frames that we are no longer tracking ("lost" frames)
-            if (frames >= Frames)
-                continue;
+            _images = temp;
+            _atlasIndices = tempAtlasIndices;
+            Data.Frames = frames;
+        }
+    }
 
-            for (var i = minFrames; i < Frames; i++)
-            {
-                _images[dir][i]?.Dispose();
-            }
+    private static int[] CreateEmptyAtlasIndices(int length)
+    {
+        var indices = new int[length];
+        Array.Fill(indices, -1);
+        return indices;
+    }
+
+    private void ReleaseAtlasFrame(StateDirection direction, int frame)
+    {
+        if (_atlasIndices[(int)direction][frame] < 0)
+        {
+            return;
         }
 
-        _images = temp;
-        Data.Frames = frames;
+        _atlasIndices[(int)direction][frame] = -1;
+        ReleaseMaterializedAtlasFrame();
+    }
+
+    private void ReleaseMaterializedAtlasFrame()
+    {
+        _unmaterializedFrameCount--;
+        if (_unmaterializedFrameCount != 0)
+        {
+            return;
+        }
+
+        _atlas?.Dispose();
+        _atlas = null;
     }
 
     /// <summary>

--- a/DMISharp/Metadata/DMIMetadata.cs
+++ b/DMISharp/Metadata/DMIMetadata.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using MetadataExtractor.Formats.Png;
+using SixLabors.ImageSharp.Formats.Png.Chunks;
 
 namespace DMISharp.Metadata;
 
@@ -40,6 +41,15 @@ public class DMIMetadata
         // Get the contents of the DMI metadata
         var data = GetDMIMetadata(stream);
         ParseMetadata(data);
+    }
+
+    internal DMIMetadata(IEnumerable<PngTextData> textData)
+    {
+        States = new List<StateMetadata>();
+        FrameWidth = -1;
+        FrameHeight = -1;
+
+        ParseMetadata(GetDMIMetadata(textData));
     }
 
     /// <summary>
@@ -92,6 +102,19 @@ public class DMIMetadata
         }
 
         return metaDesc.AsSpan()[metaDesc.IndexOf('#', StringComparison.InvariantCultureIgnoreCase)..];
+    }
+
+    private static ReadOnlySpan<char> GetDMIMetadata(IEnumerable<PngTextData> textData)
+    {
+        foreach (var text in textData)
+        {
+            if (DMIStart.IsMatch(text.Value))
+            {
+                return text.Value.AsSpan()[text.Value.IndexOf('#', StringComparison.InvariantCultureIgnoreCase)..];
+            }
+        }
+
+        throw new InvalidOperationException("Failed to find BYOND DMI metadata in PNG text data!");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Decode each DMI PNG once and parse BYOND metadata from ImageSharp's decoded `PngMetadata.TextData`, removing the separate MetadataExtractor traversal and stream rewind.
- Lazily materialize frames from a reference-counted shared atlas while preserving independently mutable, state-owned `Image<Rgba32>` instances.
- Add focused load and full-materialization benchmarks plus ownership, concurrency, removed-state lifetime, and non-seekable-stream coverage.

## Benchmarks

BenchmarkDotNet 0.13.12 with `MemoryDiagnoser` on .NET 8.0.28, Windows 11, and an AMD Ryzen 7 5800X3D. Each row was measured in the same run, comparing the released DMISharp 2.0.2 NuGet package with this branch. `ReadDMIFile` constructs and disposes the file. `ReadAndMaterializeAllFrames` additionally calls `GetFrame` for every state/frame/direction before disposal.

### Load only

| Asset | 2.0.2 mean | This branch mean | 2.0.2 allocated | This branch allocated |
|---|---:|---:|---:|---:|
| `small.dmi` | 382.2 us | 343.2 us | 35.39 KB | 15.36 KB |
| `large.dmi` | 16.733 ms | 11.577 ms | 4,676.24 KB | 111.25 KB |
| `352x352.dmi` | 33.170 ms | 30.853 ms | 96.69 KB | 37.67 KB |

The largest allocation reduction is `large.dmi`: 97.6% less managed allocation and no measured Gen0/Gen1 collections during load.

### Load and fully materialize every frame

| Asset | 2.0.2 mean | This branch mean | 2.0.2 allocated | This branch allocated |
|---|---:|---:|---:|---:|
| `small.dmi` | 382.3 us | 358.0 us | 35.45 KB | 25.06 KB |
| `large.dmi` | 15.646 ms | 16.674 ms | 4,676.33 KB | 4,597.98 KB |
| `352x352.dmi` | 33.039 ms | 34.330 ms | 96.70 KB | 54.91 KB |

An intermediate benchmark captured before lazy materialization showed that removing only the duplicate metadata pass improved mean load time by 21.3% (`small`), 8.2% (`large`), and 10.8% (`352x352`), with allocation reductions of 32.1%, 2.2%, and 44.0%, respectively.

## Tradeoffs and correctness

Lazy materialization intentionally moves each frame's unavoidable allocation and pixel copy to its first `GetFrame` call. The decoded atlas remains alive until its states are disposed or all their frames are materialized. Workloads that touch every frame therefore return to roughly the previous allocation level; `large.dmi` full materialization is 6.6% slower than 2.0.2 because it also pays lazy bookkeeping and synchronization. Workloads that inspect metadata or only a subset of frames retain the load-time and GC gains.

Each materialized frame is still an independent `Image<Rgba32>` with the same mutation, replacement, deletion, and disposal ownership semantics. Atlas references survive `RemoveState` and `ImportStates`, so transferred or detached states remain usable after the source file is disposed. A shared lock serializes first materialization with frame mutation/resizing/disposal, and concurrent first reads return the same owned frame.

Because ImageSharp exposes PNG iTXt/tEXt/zTXt data after decode, `DMIFile(Stream)` no longer seeks or rereads its input. It now accepts non-seekable streams, disposes them as before, and can materialize frames after the input stream has closed. The public `DMIMetadata.GetDMIMetadata(Stream)` API remains unchanged.

## Validation

- Release build succeeds for all target frameworks.
- 29 tests pass for each of net6.0, net7.0, and net8.0 (87 runs total; net6/net7 rolled forward to the installed runtime).
- Final diff review found no remaining correctness or lifetime issues.