### PR TITLE
Update GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,13 @@ jobs:
         run: |
           echo ("PRNumber=${{ github.event.pull_request.number }}") >> $env:GITHUB_ENV
         if: matrix.job.name == 'windows'
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             6.0.424
             7.0.410
             8.0.303
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Restore dependencies
@@ -43,7 +43,7 @@ jobs:
       - name: Test
         run: dotnet test --no-build --verbosity normal DMISharp.Tests/DMISharp.Tests.csproj --logger GitHubActions
       - if: matrix.job.name == 'ubuntu'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: NuGet packages
           path: ./**/*.nupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
   release:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.303
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - run: dotnet build --configuration Release --nologo
       - name: push
         env:


### PR DESCRIPTION
## Summary
- update `actions/checkout` from v3 to v7 in CI and release workflows
- update `actions/setup-dotnet` from v3 to v5 in CI and release workflows
- update `actions/upload-artifact` from deprecated v3 to v7 in CI

## Context
All performance PR checks currently fail during job setup because GitHub rejects `actions/upload-artifact@v3`. These are the latest stable major releases published by the official action repositories as of July 9, 2026.