### PR TITLE
Upgrade to .NET 10 and latest dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build
         run: dotnet build --no-restore
       - name: Test
-        run: dotnet test --no-build --verbosity normal DMISharp.Tests/DMISharp.Tests.csproj --logger GitHubActions
+        run: dotnet test --project DMISharp.Tests/DMISharp.Tests.csproj --no-build --verbosity normal
       - if: matrix.job.name == 'ubuntu'
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,8 @@ jobs:
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
-            6.0.424
-            7.0.410
-            8.0.303
+            8.0.x
+            10.0.x
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.303
+          dotnet-version: 10.0.x
       - uses: actions/checkout@v7
       - run: dotnet build --configuration Release --nologo
       - name: push

--- a/DMISharp.Benchmark/DMIBenchmarks.cs
+++ b/DMISharp.Benchmark/DMIBenchmarks.cs
@@ -46,10 +46,24 @@ internal sealed class DMIReadBenchmarkConfig : ManualConfig
 {
     public DMIReadBenchmarkConfig()
     {
-        var baseJob = Job.Default.WithRuntime(CoreRuntime.Core80);
+        AddJob(Job.Default.WithRuntime(CoreRuntime.Core80).AsBaseline());
+        AddJob(Job.Default.WithRuntime(CoreRuntime.Core10_0));
+    }
+}
 
-        AddJob(baseJob.WithNuGet("DMISharp", "2.0.2").AsBaseline());
-        AddJob(baseJob);
+internal sealed class Net8And10BenchmarkConfig : ManualConfig
+{
+    public Net8And10BenchmarkConfig()
+    {
+        AddJob(Job.Default
+            .WithRuntime(CoreRuntime.Core80)
+            .WithWarmupCount(3)
+            .WithIterationCount(5)
+            .AsBaseline());
+        AddJob(Job.Default
+            .WithRuntime(CoreRuntime.Core10_0)
+            .WithWarmupCount(3)
+            .WithIterationCount(5));
     }
 }
 
@@ -61,11 +75,8 @@ public class DMIBenchmarks
     {
         public DMIBenchmarkConfig()
         {
-            var baseJob = Job.Default;
-            
-            AddJob(baseJob.WithNuGet("DMISharp", "2.0.2").WithRuntime(CoreRuntime.Core70).AsBaseline());
-            AddJob(baseJob.WithRuntime(CoreRuntime.Core70));
-            AddJob(baseJob.WithRuntime(CoreRuntime.Core80));
+            AddJob(Job.Default.WithRuntime(CoreRuntime.Core80).AsBaseline());
+            AddJob(Job.Default.WithRuntime(CoreRuntime.Core10_0));
         }
     }
     

--- a/DMISharp.Benchmark/DMISaveBenchmarks.cs
+++ b/DMISharp.Benchmark/DMISaveBenchmarks.cs
@@ -2,8 +2,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Environments;
-using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Order;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -12,7 +10,7 @@ namespace DMISharp.Benchmark;
 
 [MemoryDiagnoser]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
-[SimpleJob(RuntimeMoniker.Net80, warmupCount: 3, iterationCount: 5)]
+[Config(typeof(Net8And10BenchmarkConfig))]
 public class DMISaveBenchmarks
 {
     private const int FrameSize = 32;

--- a/DMISharp.Benchmark/DMISharp.Benchmark.csproj
+++ b/DMISharp.Benchmark/DMISharp.Benchmark.csproj
@@ -2,11 +2,11 @@
     
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     </ItemGroup>
     
 

--- a/DMISharp.Benchmark/DMIStateOperationBenchmarks.cs
+++ b/DMISharp.Benchmark/DMIStateOperationBenchmarks.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Jobs;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -10,7 +9,7 @@ using SixLabors.ImageSharp.PixelFormats;
 namespace DMISharp.Benchmark;
 
 [MemoryDiagnoser]
-[SimpleJob(RuntimeMoniker.Net80)]
+[Config(typeof(Net8And10BenchmarkConfig))]
 public class ImportStatesBenchmarks
 {
     private DMIFile _destination = null!;
@@ -43,7 +42,7 @@ public class ImportStatesBenchmarks
 }
 
 [MemoryDiagnoser]
-[SimpleJob(RuntimeMoniker.Net80)]
+[Config(typeof(Net8And10BenchmarkConfig))]
 public class StateCollectionBenchmarks
 {
     private DMIFile _file = null!;
@@ -63,7 +62,7 @@ public class StateCollectionBenchmarks
 }
 
 [MemoryDiagnoser]
-[SimpleJob(RuntimeMoniker.Net80)]
+[Config(typeof(Net8And10BenchmarkConfig))]
 public class StateReadinessBenchmarks
 {
     private DMIState _state = null!;
@@ -98,7 +97,7 @@ public class StateReadinessBenchmarks
 }
 
 [MemoryDiagnoser]
-[SimpleJob(RuntimeMoniker.Net80)]
+[Config(typeof(Net8And10BenchmarkConfig))]
 public class StateDisposalBenchmarks
 {
     private DMIState _state = null!;

--- a/DMISharp.Benchmark/OptimizationBenchmarks.cs
+++ b/DMISharp.Benchmark/OptimizationBenchmarks.cs
@@ -1,12 +1,11 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Jobs;
 
 namespace DMISharp.Benchmark;
 
 [MemoryDiagnoser]
-[SimpleJob(RuntimeMoniker.Net80)]
+[Config(typeof(Net8And10BenchmarkConfig))]
 [SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable",
     Justification = "BenchmarkDotNet invokes GlobalCleanup after benchmark execution.")]
 public class GifConstructionBenchmarks

--- a/DMISharp.Tests/DMIAnimationTests.cs
+++ b/DMISharp.Tests/DMIAnimationTests.cs
@@ -2,14 +2,14 @@ using System;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Gif;
 using SixLabors.ImageSharp.PixelFormats;
-using Xunit;
+using System.Threading.Tasks;
 
 namespace DMISharp.Tests;
 
-public sealed class DMIAnimationTests
+internal sealed class DMIAnimationTests
 {
-    [Fact]
-    public void GetAnimatedCopiesFramesAndMetadataWithoutMutatingSources()
+    [Test]
+    public async Task GetAnimatedCopiesFramesAndMetadataWithoutMutatingSources()
     {
         using var state = new DMIState("animated", DirectionDepth.One, 2, 3, 1);
 #pragma warning disable CA2000
@@ -34,31 +34,30 @@ public sealed class DMIAnimationTests
 
         using var animation = state.GetAnimated(StateDirection.South);
 
-        Assert.Equal(2, animation.Frames.Count);
-        Assert.Equal(default, animation.Frames[0][0, 0]);
-        Assert.Equal(new Rgba32(40, 50, 60, 128), animation.Frames[0][1, 0]);
-        Assert.Equal(new Rgba32(70, 80, 90, 255), animation.Frames[0][2, 0]);
+        await Assert.That(animation.Frames.Count).IsEqualTo(2);
+        await Assert.That(animation.Frames[0][0, 0]).IsEqualTo(default);
+        await Assert.That(animation.Frames[0][1, 0]).IsEqualTo(new Rgba32(40, 50, 60, 128));
+        await Assert.That(animation.Frames[0][2, 0]).IsEqualTo(new Rgba32(70, 80, 90, 255));
 
         var gifMetadata = animation.Metadata.GetFormatMetadata(GifFormat.Instance);
-        Assert.Equal(GifColorTableMode.Local, gifMetadata.ColorTableMode);
-        Assert.Equal(3, gifMetadata.RepeatCount);
-        Assert.Equal(15, animation.Frames[0].Metadata.GetFormatMetadata(GifFormat.Instance).FrameDelay);
-        Assert.Equal(25, animation.Frames[1].Metadata.GetFormatMetadata(GifFormat.Instance).FrameDelay);
+        await Assert.That(gifMetadata.ColorTableMode).IsEqualTo(GifColorTableMode.Local);
+        await Assert.That(gifMetadata.RepeatCount).IsEqualTo((ushort)3);
+        await Assert.That(animation.Frames[0].Metadata.GetFormatMetadata(GifFormat.Instance).FrameDelay).IsEqualTo(15);
+        await Assert.That(animation.Frames[1].Metadata.GetFormatMetadata(GifFormat.Instance).FrameDelay).IsEqualTo(25);
         foreach (var frame in animation.Frames)
         {
-            Assert.Equal(GifDisposalMethod.RestoreToBackground,
-                frame.Metadata.GetFormatMetadata(GifFormat.Instance).DisposalMethod);
+            await Assert.That(frame.Metadata.GetFormatMetadata(GifFormat.Instance).DisposalMethod).IsEqualTo(GifDisposalMethod.RestoreToBackground);
         }
 
-        Assert.Equal(new Rgba32(10, 20, 30, 0), first[0, 0]);
-        Assert.Equal(99, firstSourceMetadata.FrameDelay);
-        Assert.Equal(GifDisposalMethod.NotDispose, firstSourceMetadata.DisposalMethod);
-        Assert.Equal(98, secondSourceMetadata.FrameDelay);
-        Assert.Equal(GifDisposalMethod.RestoreToPrevious, secondSourceMetadata.DisposalMethod);
+        await Assert.That(first[0, 0]).IsEqualTo(new Rgba32(10, 20, 30, 0));
+        await Assert.That(firstSourceMetadata.FrameDelay).IsEqualTo(99);
+        await Assert.That(firstSourceMetadata.DisposalMethod).IsEqualTo(GifDisposalMethod.NotDispose);
+        await Assert.That(secondSourceMetadata.FrameDelay).IsEqualTo(98);
+        await Assert.That(secondSourceMetadata.DisposalMethod).IsEqualTo(GifDisposalMethod.RestoreToPrevious);
     }
 
-    [Fact]
-    public void GetAnimatedMissingFrameDoesNotMutateEarlierFrames()
+    [Test]
+    public async Task GetAnimatedMissingFrameDoesNotMutateEarlierFrames()
     {
         using var state = new DMIState("incomplete", DirectionDepth.One, 2, 1, 1);
 #pragma warning disable CA2000
@@ -71,8 +70,8 @@ public sealed class DMIAnimationTests
         state.InitializeDelay();
 
         Assert.Throws<InvalidOperationException>(() => state.GetAnimated(StateDirection.South));
-        Assert.Equal(new Rgba32(10, 20, 30, 0), first[0, 0]);
-        Assert.Equal(99, sourceMetadata.FrameDelay);
-        Assert.Equal(GifDisposalMethod.NotDispose, sourceMetadata.DisposalMethod);
+        await Assert.That(first[0, 0]).IsEqualTo(new Rgba32(10, 20, 30, 0));
+        await Assert.That(sourceMetadata.FrameDelay).IsEqualTo(99);
+        await Assert.That(sourceMetadata.DisposalMethod).IsEqualTo(GifDisposalMethod.NotDispose);
     }
 }

--- a/DMISharp.Tests/DMICreationTests.cs
+++ b/DMISharp.Tests/DMICreationTests.cs
@@ -2,13 +2,13 @@
 using System.Linq;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-using Xunit;
+using System.Threading.Tasks;
 
 namespace DMISharp.Tests;
 
-public class DMICreationTests
+internal sealed class DMICreationTests
 {
-    [Fact]
+    [Test]
     public void CanMergeDMI()
     {
         using var newDMI = new DMIFile(32, 32);
@@ -22,7 +22,7 @@ public class DMICreationTests
         newDMI.Save(@"Data/Output/merged.dmi");
     }
 
-    [Fact]
+    [Test]
     public void CanCreateDMIFromImages()
     {
         using var newDMI = new DMIFile(32, 32);
@@ -41,13 +41,13 @@ public class DMICreationTests
         newDMI.Save(@"Data/Output/minecraft.dmi");
     }
 
-    [Fact]
-    public void CanChangeDMIDepths()
+    [Test]
+    public async Task CanChangeDMIDepths()
     {
         using var newDMI = new DMIFile(32, 32);
 
         // Create state
-        var img = Image.Load<Rgba32>($@"Data/Input/SourceImages/steve32.png");
+        var img = await Image.LoadAsync<Rgba32>($@"Data/Input/SourceImages/steve32.png").ConfigureAwait(false);
 #pragma warning disable CA2000
         var newState = new DMIState("steve32", DirectionDepth.One, 1, 32, 32);
 #pragma warning restore CA2000
@@ -59,10 +59,10 @@ public class DMICreationTests
         newDMI.States.First().SetFrameCount(10);
 
         // Check new states
-        Assert.Equal(DirectionDepth.Four, newDMI.States.First().DirectionDepth);
-        Assert.Equal(10, newDMI.States.First().Frames);
+        await Assert.That(newDMI.States.First().DirectionDepth).IsEqualTo(DirectionDepth.Four);
+        await Assert.That(newDMI.States.First().Frames).IsEqualTo(10);
 
         // Cannot save
-        Assert.False(newDMI.CanSave());
+        await Assert.That(newDMI.CanSave()).IsFalse();
     }
 }

--- a/DMISharp.Tests/DMIModifyTests.cs
+++ b/DMISharp.Tests/DMIModifyTests.cs
@@ -3,14 +3,15 @@ using System.Linq;
 using DMISharp.Metadata;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-using Xunit;
+using System.Threading.Tasks;
+using TUnit.Assertions.Enums;
 
 namespace DMISharp.Tests;
 
-public static class DMIModifyTests
+internal sealed class DMIModifyTests
 {
-    [Fact]
-    public static void ShouldRemoveStateMetadata()
+    [Test]
+    public async Task ShouldRemoveStateMetadata()
     {
         using var file = new DMIFile(@"Data/Input/turf_analysis.dmi");
 
@@ -23,25 +24,25 @@ public static class DMIModifyTests
         stateToRemove.Dispose();
 
         // Assert
-        Assert.True(result);
-        Assert.Equal(mdCount - 1, file.Metadata.States.Count);
+        await Assert.That(result).IsTrue();
+        await Assert.That(file.Metadata.States.Count).IsEqualTo(mdCount - 1);
     }
 
-    [Fact]
-    public static void ShouldDetectValidUnmodifiedDMIState()
+    [Test]
+    public async Task ShouldDetectValidUnmodifiedDMIState()
     {
         // Arrange
         using var file = new DMIFile(@"Data/Input/turf_analysis.dmi");
 
         // Act
         var arrowState = file.States.First(x => x.Name == "arrow");
-            
+
         // Assert
-        Assert.True(arrowState.IsReadyForSave());
+        await Assert.That(arrowState.IsReadyForSave()).IsTrue();
     }
 
-    [Fact]
-    public static void ShouldDetectInvalidDMIStateMissingFrame()
+    [Test]
+    public async Task ShouldDetectInvalidDMIStateMissingFrame()
     {
         // Arrange
         using var file = new DMIFile(@"Data/Input/turf_analysis.dmi");
@@ -49,14 +50,14 @@ public static class DMIModifyTests
         // Act
         var arrowState = file.States.First(x => x.Name == "arrow");
         arrowState.DeleteFrame(0);
-            
+
         // Assert
-        Assert.False(arrowState.IsReadyForSave());
-        Assert.False(file.CanSave());
+        await Assert.That(arrowState.IsReadyForSave()).IsFalse();
+        await Assert.That(file.CanSave()).IsFalse();
     }
 
-    [Fact]
-    public static void ShouldDetectInvalidDMIStateMissingDirection()
+    [Test]
+    public async Task ShouldDetectInvalidDMIStateMissingDirection()
     {
         // Arrange
         using var file = new DMIFile(@"Data/Input/turf_analysis.dmi");
@@ -64,28 +65,28 @@ public static class DMIModifyTests
         // Act
         var arrowState = file.States.First(x => x.Name == "arrow");
         arrowState.SetDirectionDepth(DirectionDepth.Eight);
-            
+
         // Assert
-        Assert.False(arrowState.IsReadyForSave());
-        Assert.False(file.CanSave());
+        await Assert.That(arrowState.IsReadyForSave()).IsFalse();
+        await Assert.That(file.CanSave()).IsFalse();
     }
 
-    [Fact]
+    [Test]
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
-    public static void StatesShouldReuseReadOnlyView()
+    public async Task StatesShouldReuseReadOnlyView()
     {
         using var file = new DMIFile(1, 1);
         var view = file.States;
 
         file.AddState(new DMIState("state", DirectionDepth.One, 1, 1, 1));
 
-        Assert.Same(view, file.States);
-        Assert.Single(view);
+        await Assert.That(file.States).IsSameReferenceAs(view);
+        await Assert.That(view).HasSingleItem();
     }
 
-    [Fact]
+    [Test]
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
-    public static void StatesViewShouldRemainLiveAfterSorting()
+    public async Task StatesViewShouldRemainLiveAfterSorting()
     {
         using var file = new DMIFile(1, 1);
         file.AddState(new DMIState("second", DirectionDepth.One, 1, 1, 1));
@@ -94,13 +95,14 @@ public static class DMIModifyTests
 
         file.SortStates();
 
-        Assert.Same(view, file.States);
-        Assert.Equal(new[] { "first", "second" }, view.Select(state => state.Name));
+        await Assert.That(file.States).IsSameReferenceAs(view);
+        await Assert.That(view.Select(state => state.Name))
+            .IsEquivalentTo(new[] { "first", "second" }, CollectionOrdering.Matching);
     }
 
-    [Fact]
+    [Test]
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
-    public static void ImportStatesShouldPreserveOrderMetadataAndOwnership()
+    public async Task ImportStatesShouldPreserveOrderMetadataAndOwnership()
     {
         using var destination = new DMIFile(1, 1);
         using var source = new DMIFile(1, 1);
@@ -115,17 +117,19 @@ public static class DMIModifyTests
         var added = destination.ImportStates(source);
         source.Dispose();
 
-        Assert.Equal(2, added);
-        Assert.Equal(new[] { existing, first, second }, destination.States);
-        Assert.Equal(destination.States.Select(state => state.Data), destination.Metadata.States);
-        Assert.Empty(source.States);
-        Assert.Empty(source.Metadata.States);
-        Assert.Equal(1, first.TotalFrames);
+        await Assert.That(added).IsEqualTo(2);
+        await Assert.That(destination.States)
+            .IsEquivalentTo(new[] { existing, first, second }, CollectionOrdering.Matching);
+        await Assert.That(destination.Metadata.States)
+            .IsEquivalentTo(destination.States.Select(state => state.Data), CollectionOrdering.Matching);
+        await Assert.That(source.States).IsEmpty();
+        await Assert.That(source.Metadata.States).IsEmpty();
+        await Assert.That(first.TotalFrames).IsEqualTo(1);
     }
 
-    [Fact]
+    [Test]
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
-    public static void ImportStatesShouldPreserveUnrelatedMetadata()
+    public async Task ImportStatesShouldPreserveUnrelatedMetadata()
     {
         using var destination = new DMIFile(1, 1);
         using var source = new DMIFile(1, 1);
@@ -139,7 +143,9 @@ public static class DMIModifyTests
 
         destination.ImportStates(source);
 
-        Assert.Equal(new[] { unrelated }, source.Metadata.States);
-        Assert.Equal(new[] { first.Data, second.Data }, destination.Metadata.States);
+        await Assert.That(source.Metadata.States)
+            .IsEquivalentTo(new[] { unrelated }, CollectionOrdering.Matching);
+        await Assert.That(destination.Metadata.States)
+            .IsEquivalentTo(new[] { first.Data, second.Data }, CollectionOrdering.Matching);
     }
 }

--- a/DMISharp.Tests/DMIReadTests.cs
+++ b/DMISharp.Tests/DMIReadTests.cs
@@ -3,56 +3,55 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.PixelFormats;
-using Xunit;
 
 namespace DMISharp.Tests;
 
-public class DMIReadTests
+internal sealed class DMIReadTests
 {
-    [Fact]
-    public void AnimalDMIStateCount()
+    [Test]
+    public async Task AnimalDMIStateCount()
     {
         using var file = new DMIFile(@"Data/Input/animal.dmi");
-        Assert.Equal(154, file.States.Count);
+        await Assert.That(file.States.Count).IsEqualTo(154);
     }
 
-    [Fact]
-    public void AirMeterDMIStateCount()
+    [Test]
+    public async Task AirMeterDMIStateCount()
     {
         using var file = new DMIFile(@"Data/Input/air_meter.dmi");
-        Assert.Equal(16, file.States.Count);
+        await Assert.That(file.States.Count).IsEqualTo(16);
     }
 
-    [Fact]
-    public void AtmosTestingDMIStateCount()
+    [Test]
+    public async Task AtmosTestingDMIStateCount()
     {
         using var file = new DMIFile(@"Data/Input/atmos_testing.dmi");
-        Assert.Equal(5, file.States.Count);
+        await Assert.That(file.States.Count).IsEqualTo(5);
     }
 
-    [Fact]
-    public void LightingDMIStateCount()
+    [Test]
+    public async Task LightingDMIStateCount()
     {
         using var file = new DMIFile(@"Data/Input/lighting.dmi");
-        Assert.Equal(3, file.States.Count);
+        await Assert.That(file.States.Count).IsEqualTo(3);
     }
 
-    [Fact]
-    public void TurfAnalysisDMIStateCount()
+    [Test]
+    public async Task TurfAnalysisDMIStateCount()
     {
         using var file = new DMIFile(@"Data/Input/turf_analysis.dmi");
-        Assert.Equal(16, file.States.Count);
+        await Assert.That(file.States.Count).IsEqualTo(16);
     }
 
-    [Fact]
-    public void SpaceDragonDMIStateCount()
+    [Test]
+    public async Task SpaceDragonDMIStateCount()
     {
         using var file = new DMIFile(@"Data/Input/spacedragon.dmi");
-        Assert.Equal(2, file.States.Count);
+        await Assert.That(file.States.Count).IsEqualTo(2);
     }
 
-    [Fact]
-    public void CanReadDirectionDepth()
+    [Test]
+    public async Task CanReadDirectionDepth()
     {
         using var file = new DMIFile(@"Data/Input/animal.dmi");
 
@@ -62,32 +61,32 @@ public class DMIReadTests
         var rareFrogDead = file.States.First(x => x.Name == "rare_frog_dead");
 
         // Assert
-        Assert.Equal(DirectionDepth.Four, bat.DirectionDepth);
-        Assert.Equal(DirectionDepth.Four, carp.DirectionDepth);
-        Assert.Equal(DirectionDepth.One, rareFrogDead.DirectionDepth);
+        await Assert.That(bat.DirectionDepth).IsEqualTo(DirectionDepth.Four);
+        await Assert.That(carp.DirectionDepth).IsEqualTo(DirectionDepth.Four);
+        await Assert.That(rareFrogDead.DirectionDepth).IsEqualTo(DirectionDepth.One);
     }
 
-    [Fact]
-    public void GoonTurfAnalysisDMIStateCount()
+    [Test]
+    public async Task GoonTurfAnalysisDMIStateCount()
     {
         using var file = new DMIFile(@"Data/Input/turf_analysis_goon.dmi");
-        Assert.Equal(16, file.States.Count);
+        await Assert.That(file.States.Count).IsEqualTo(16);
     }
 
-    [Fact]
-    public void CanReadFromNonSeekableStream()
+    [Test]
+    public async Task CanReadFromNonSeekableStream()
     {
         var stream = new NonSeekableReadStream(File.OpenRead(@"Data/Input/animal.dmi"));
 
         using var file = new DMIFile(stream);
 
-        Assert.Equal(154, file.States.Count);
-        Assert.True(stream.IsDisposed);
-        Assert.NotNull(file.States.First().GetFrame(0));
+        await Assert.That(file.States.Count).IsEqualTo(154);
+        await Assert.That(stream.IsDisposed).IsTrue();
+        await Assert.That(file.States.First().GetFrame(0)).IsNotNull();
     }
 
-    [Fact]
-    public void LoadedFramesRemainIndependentlyMutable()
+    [Test]
+    public async Task LoadedFramesRemainIndependentlyMutable()
     {
         using var file = new DMIFile(@"Data/Input/animal.dmi");
         var state = file.States.First(x => x.Name == "mushroom");
@@ -98,29 +97,29 @@ public class DMIReadTests
 
         first[0, 0] = replacement;
 
-        Assert.Equal(replacement, first[0, 0]);
-        Assert.Equal(secondPixel, second[0, 0]);
-        Assert.Same(first, state.GetFrame(StateDirection.South, 0));
+        await Assert.That(first[0, 0]).IsEqualTo(replacement);
+        await Assert.That(second[0, 0]).IsEqualTo(secondPixel);
+        await Assert.That(state.GetFrame(StateDirection.South, 0)).IsSameReferenceAs(first);
     }
 
-    [Fact]
-    public void RemovedStateRetainsUnmaterializedFrames()
+    [Test]
+    public async Task RemovedStateRetainsUnmaterializedFrames()
     {
         DMIState state;
         using (var file = new DMIFile(@"Data/Input/turf_analysis.dmi"))
         {
             state = file.States.Last();
-            Assert.True(file.RemoveState(state));
+            await Assert.That(file.RemoveState(state)).IsTrue();
         }
 
         using (state)
         {
-            Assert.NotNull(state.GetFrame(0));
+            await Assert.That(state.GetFrame(0)).IsNotNull();
         }
     }
 
-    [Fact]
-    public void ConcurrentFrameReadsReturnSameOwnedImage()
+    [Test]
+    public async Task ConcurrentFrameReadsReturnSameOwnedImage()
     {
         using var file = new DMIFile(@"Data/Input/animal.dmi");
         var state = file.States.First(x => x.Name == "mushroom");
@@ -128,7 +127,8 @@ public class DMIReadTests
 
         Parallel.For(0, frames.Length, i => frames[i] = state.GetFrame(StateDirection.South, 0)!);
 
-        Assert.All(frames, frame => Assert.Same(frames[0], frame));
+        foreach (var frame in frames)
+            await Assert.That(frame).IsSameReferenceAs(frames[0]);
     }
 
     private sealed class NonSeekableReadStream : Stream

--- a/DMISharp.Tests/DMISharp.Tests.csproj
+++ b/DMISharp.Tests/DMISharp.Tests.csproj
@@ -1,22 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="GitHubActionsTestLogger" Version="3.0.4">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
         <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="TUnit" Version="1.58.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DMISharp.Tests/DMISharp.Tests.csproj
+++ b/DMISharp.Tests/DMISharp.Tests.csproj
@@ -2,22 +2,18 @@
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
+        <PackageReference Include="GitHubActionsTestLogger" Version="3.0.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
-        <PackageReference Include="xunit" Version="2.9.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/DMISharp.Tests/DMIWriteTests.cs
+++ b/DMISharp.Tests/DMIWriteTests.cs
@@ -66,6 +66,21 @@ public class DMIWriteTests
         file.Save(@"Data/Output/animal_sorted_alphabetically.dmi");
     }
 
+    [Theory]
+    [InlineData("air_meter.dmi", false, 481)]
+    [InlineData("animal.dmi", true, 136490)]
+    public void SavePreservesCompressionOutputSize(string fileName, bool sort, long expectedLength)
+    {
+        using var output = new MemoryStream();
+        using var file = new DMIFile(Path.Combine("Data", "Input", fileName));
+        if (sort)
+            file.SortStates();
+
+        file.Save(output);
+
+        Assert.Equal(expectedLength, output.Length);
+    }
+
     [Fact]
     public void CanWriteAnimations()
     {

--- a/DMISharp.Tests/DMIWriteTests.cs
+++ b/DMISharp.Tests/DMIWriteTests.cs
@@ -3,16 +3,18 @@ using System.Linq;
 using DMISharp.Metadata;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-using Xunit;
+using System.Threading.Tasks;
+using TUnit.Assertions.Enums;
 
 namespace DMISharp.Tests;
 
-public class DMIWriteTests
+[NotInParallel]
+internal sealed class DMIWriteTests
 {
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public void SaveProducesIdenticalOutputAcrossStreamCapabilities(bool trueColor)
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task SaveProducesIdenticalOutputAcrossStreamCapabilities(bool trueColor)
     {
         using var file = CreateSyntheticFile(trueColor);
         using var expectedStream = new MemoryStream();
@@ -23,42 +25,46 @@ public class DMIWriteTests
         using var appendStream = new MemoryStream();
         appendStream.Write(prefix);
         file.Save(appendStream);
-        Assert.Equal(prefix.Concat(expected), appendStream.ToArray());
+        await Assert.That(appendStream.ToArray())
+            .IsEquivalentTo(prefix.Concat(expected), CollectionOrdering.Matching);
 
         using var nonSeekableOutput = new MemoryStream();
         using (var nonSeekableStream = new NonSeekableWriteStream(nonSeekableOutput))
             file.Save(nonSeekableStream);
-        Assert.Equal(expected, nonSeekableOutput.ToArray());
+        await Assert.That(nonSeekableOutput.ToArray())
+            .IsEquivalentTo(expected, CollectionOrdering.Matching);
 
         var overwriteBuffer = Enumerable.Repeat((byte)0xA5, expected.Length + 64).ToArray();
         using var overwriteStream = new MemoryStream(overwriteBuffer, writable: true);
         file.Save(overwriteStream);
-        Assert.Equal(expected, overwriteBuffer.Take(expected.Length));
-        Assert.All(overwriteBuffer.Skip(expected.Length), value => Assert.Equal(0xA5, value));
+        await Assert.That(overwriteBuffer.Take(expected.Length))
+            .IsEquivalentTo(expected, CollectionOrdering.Matching);
+        foreach (var value in overwriteBuffer.Skip(expected.Length))
+            await Assert.That(value).IsEqualTo((byte)0xA5);
     }
 
-    [Fact]
-    public void SaveKeepsUnusedAtlasCellsTransparent()
+    [Test]
+    public async Task SaveKeepsUnusedAtlasCellsTransparent()
     {
         using var file = CreateSyntheticFile(false, 3);
         using var output = new MemoryStream();
         file.Save(output);
         output.Position = 0;
 
-        using var image = Image.Load<Rgba32>(output);
-        Assert.Equal(34, image.Width);
-        Assert.Equal(34, image.Height);
-        Assert.Equal(0, image[33, 33].A);
+        using var image = await Image.LoadAsync<Rgba32>(output).ConfigureAwait(false);
+        await Assert.That(image.Width).IsEqualTo(34);
+        await Assert.That(image.Height).IsEqualTo(34);
+        await Assert.That(image[33, 33].A).IsEqualTo((byte)0);
     }
 
-    [Fact]
+    [Test]
     public void CanWriteDMIFile()
     {
         using var file = new DMIFile(@"Data/Input/air_meter.dmi");
         file.Save(@"Data/Output/air_meter_temp.dmi");
     }
 
-    [Fact]
+    [Test]
     public void CanSortDMIFile()
     {
         using var file = new DMIFile(@"Data/Input/animal.dmi");
@@ -66,10 +72,10 @@ public class DMIWriteTests
         file.Save(@"Data/Output/animal_sorted_alphabetically.dmi");
     }
 
-    [Theory]
-    [InlineData("air_meter.dmi", false, 481)]
-    [InlineData("animal.dmi", true, 136490)]
-    public void SavePreservesCompressionOutputSize(string fileName, bool sort, long expectedLength)
+    [Test]
+    [Arguments("air_meter.dmi", false, 481)]
+    [Arguments("animal.dmi", true, 136490)]
+    public async Task SavePreservesCompressionOutputSize(string fileName, bool sort, long expectedLength)
     {
         using var output = new MemoryStream();
         using var file = new DMIFile(Path.Combine("Data", "Input", fileName));
@@ -78,10 +84,10 @@ public class DMIWriteTests
 
         file.Save(output);
 
-        Assert.Equal(expectedLength, output.Length);
+        await Assert.That(output.Length).IsEqualTo(expectedLength);
     }
 
-    [Fact]
+    [Test]
     public void CanWriteAnimations()
     {
         using var file = new DMIFile(@"Data/Input/animal.dmi");
@@ -97,7 +103,7 @@ public class DMIWriteTests
     /// <summary>
     /// Tests if gif frames are accidentally disposed after creating animation
     /// </summary>
-    [Fact]
+    [Test]
     public void AnimationConstructDoesNotDisposeFrames()
     {
         using var file = new DMIFile(@"Data/Input/animal.dmi");
@@ -116,7 +122,7 @@ public class DMIWriteTests
         }
     }
 
-    [Fact]
+    [Test]
     public void AnimationOfBarsignsConstructsCorrectly()
     {
         using var fs = File.OpenWrite(@"Data/Output/thegreytide.gif");
@@ -125,7 +131,7 @@ public class DMIWriteTests
         toTest.SaveAnimatedGIF(fs, StateDirection.South);
     }
 
-    [Fact]
+    [Test]
     public void AnimationOfSingularityConstructsCorrectly()
     {
         using var fs = File.OpenWrite(@"Data/Output/singularity_s11.gif");
@@ -134,43 +140,43 @@ public class DMIWriteTests
         toTest.SaveAnimatedGIF(fs, StateDirection.South);
     }
 
-    [Theory]
-    [InlineData(@"Data/Input/broadMobs.dmi", @"Data/Output/broadMobs.dmi")]
-    public void ResavingFileMatchesOriginalMetadata(string inputPath, string outputPath)
+    [Test]
+    [Arguments(@"Data/Input/broadMobs.dmi", @"Data/Output/broadMobs.dmi")]
+    public async Task ResavingFileMatchesOriginalMetadata(string inputPath, string outputPath)
     {
         if (File.Exists(outputPath))
             File.Delete(outputPath);
-            
+
         using (var fs = File.OpenWrite(outputPath))
         using (var originalFile = new DMIFile(inputPath))
             originalFile.Save(fs);
-            
+
         // Check metadata is equal
         using var oldFile = File.OpenRead(inputPath);
         using var newFile = File.OpenRead(outputPath);
-        Assert.Equal(DMIMetadata.GetDMIMetadata(oldFile).ToString(), DMIMetadata.GetDMIMetadata(newFile).ToString());
+        await Assert.That(DMIMetadata.GetDMIMetadata(newFile).ToString()).IsEqualTo(DMIMetadata.GetDMIMetadata(oldFile).ToString());
     }
-        
-    [Theory]
-    [InlineData(@"Data/Input/broadMobs.dmi", @"Data/Output/broadMobs.dmi")]
-    public void ResavingFileMatchesOriginalImageRectSprites(string inputPath, string outputPath)
+
+    [Test]
+    [Arguments(@"Data/Input/broadMobs.dmi", @"Data/Output/broadMobs.dmi")]
+    public async Task ResavingFileMatchesOriginalImageRectSprites(string inputPath, string outputPath)
     {
         if (File.Exists(outputPath))
             File.Delete(outputPath);
-            
+
         using (var fs = File.OpenWrite(outputPath))
         using (var originalFile = new DMIFile(inputPath))
             originalFile.Save(fs);
-            
+
         // Check image is equal
         var pixelDiffs = 0;
-        using var oldFile = Image.Load<Rgba32>(inputPath);
-        using var newFile = Image.Load<Rgba32>(outputPath);
-        
+        using var oldFile = await Image.LoadAsync<Rgba32>(inputPath).ConfigureAwait(false);
+        using var newFile = await Image.LoadAsync<Rgba32>(outputPath).ConfigureAwait(false);
+
         // Check overall dimensions
-        Assert.Equal(oldFile.Width, newFile.Width);
-        Assert.Equal(oldFile.Height, newFile.Height);
-                
+        await Assert.That(newFile.Width).IsEqualTo(oldFile.Width);
+        await Assert.That(newFile.Height).IsEqualTo(oldFile.Height);
+
         // Check pixel content
         var height = oldFile.Height;
         var width = oldFile.Width;
@@ -188,29 +194,29 @@ public class DMIWriteTests
             }
         });
 
-        Assert.Equal(0, pixelDiffs);
+        await Assert.That(pixelDiffs).IsEqualTo(0);
     }
-        
-    [Theory]
-    [InlineData(@"Data/Input/animal.dmi", @"Data/Output/animal.dmi")]
-    public void ResavingFileMatchesOriginalImageSquareSprites(string inputPath, string outputPath)
+
+    [Test]
+    [Arguments(@"Data/Input/animal.dmi", @"Data/Output/animal.dmi")]
+    public async Task ResavingFileMatchesOriginalImageSquareSprites(string inputPath, string outputPath)
     {
         if (File.Exists(outputPath))
             File.Delete(outputPath);
-            
+
         using (var fs = File.OpenWrite(outputPath))
         using (var originalFile = new DMIFile(inputPath))
             originalFile.Save(fs);
-            
+
         // Check image is equal
         var pixelDiffs = 0;
-        using var oldFile = Image.Load<Rgba32>(inputPath);
-        using var newFile = Image.Load<Rgba32>(outputPath);
-        
+        using var oldFile = await Image.LoadAsync<Rgba32>(inputPath).ConfigureAwait(false);
+        using var newFile = await Image.LoadAsync<Rgba32>(outputPath).ConfigureAwait(false);
+
         // Check overall dimensions
-        Assert.Equal(oldFile.Width, newFile.Width);
-        Assert.Equal(oldFile.Height, newFile.Height);
-                
+        await Assert.That(newFile.Width).IsEqualTo(oldFile.Width);
+        await Assert.That(newFile.Height).IsEqualTo(oldFile.Height);
+
         // Check pixel content
         var height = oldFile.Height;
         var width = oldFile.Width;
@@ -228,29 +234,29 @@ public class DMIWriteTests
             }
         });
 
-        Assert.Equal(0, pixelDiffs);
+        await Assert.That(pixelDiffs).IsEqualTo(0);
     }
-        
-    [Theory]
-    [InlineData(@"Data/Input/light_64.dmi", @"Data/Output/light_64.dmi")]
-    public void ResavingFileMatchesOriginalImageSingleSprite(string inputPath, string outputPath)
+
+    [Test]
+    [Arguments(@"Data/Input/light_64.dmi", @"Data/Output/light_64.dmi")]
+    public async Task ResavingFileMatchesOriginalImageSingleSprite(string inputPath, string outputPath)
     {
         if (File.Exists(outputPath))
             File.Delete(outputPath);
-            
+
         using (var fs = File.OpenWrite(outputPath))
         using (var originalFile = new DMIFile(inputPath))
             originalFile.Save(fs);
-            
+
         // Check image is equal
         var pixelDiffs = 0;
-        using var oldFile = Image.Load<Rgba32>(inputPath);
-        using var newFile = Image.Load<Rgba32>(outputPath);
-        
+        using var oldFile = await Image.LoadAsync<Rgba32>(inputPath).ConfigureAwait(false);
+        using var newFile = await Image.LoadAsync<Rgba32>(outputPath).ConfigureAwait(false);
+
         // Check overall dimensions
-        Assert.Equal(oldFile.Width, newFile.Width);
-        Assert.Equal(oldFile.Height, newFile.Height);
-                
+        await Assert.That(newFile.Width).IsEqualTo(oldFile.Width);
+        await Assert.That(newFile.Height).IsEqualTo(oldFile.Height);
+
         // Check pixel content
         var height = oldFile.Height;
         var width = oldFile.Width;
@@ -268,7 +274,7 @@ public class DMIWriteTests
             }
         });
 
-        Assert.Equal(0, pixelDiffs);
+        await Assert.That(pixelDiffs).IsEqualTo(0);
     }
 
     private static DMIFile CreateSyntheticFile(bool trueColor, int frameCount = 1)

--- a/DMISharp/DMIFile.cs
+++ b/DMISharp/DMIFile.cs
@@ -191,7 +191,8 @@ public sealed class DMIFile : IDisposable, IExportable
         {
             InterlaceMethod = PngInterlaceMode.None,
             CompressionLevel = PngCompressionLevel.BestCompression,
-            FilterMethod = PngFilterMethod.Adaptive,
+            // ImageSharp 3.1.4 ignored explicit filters, so None preserves existing output and performance.
+            FilterMethod = PngFilterMethod.None,
             TransparentColorMode = PngTransparentColorMode.Clear,
             TextCompressionThreshold = 0, // always compress text chunks
             ChunkFilter = PngChunkFilter.ExcludePhysicalChunk | PngChunkFilter.ExcludeExifChunk |

--- a/DMISharp/DMISharp.csproj
+++ b/DMISharp/DMISharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>DMISharp</PackageId>
@@ -37,21 +37,17 @@
     </Target>
 
     <ItemGroup>
-        <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.2.2" />
-        <PackageReference Include="MetadataExtractor" Version="2.8.1" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+        <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.2" />
+        <PackageReference Include="MetadataExtractor" Version="2.9.3" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+        <PackageReference Include="MinVer" Version="7.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="MinVer" Version="5.0.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AnalysisMode>All</AnalysisMode>
-    <AnalysisLevel>6.0</AnalysisLevel>
+    <AnalysisLevel>10.0</AnalysisLevel>
     <DebugType>embedded</DebugType>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ dotnet test --project DMISharp.Tests/DMISharp.Tests.csproj
 
 ### Questions?
 
-Feel free to contact me on Discord at `@bobbahbrown` with any questions or concerns. Additionally, I can be found in the [/tg/station discord server](https://tgstation13.org/phpBB/viewforum.php?f=60).
+Feel free to contact me on Discord at `@bobbahbee` with any questions or concerns. Additionally, I can be found in the [/tg/station discord server](https://tgstation13.org/phpBB/viewforum.php?f=60).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 DMISharp
 </h1>
 
-### **DMISharp** is a .NET 8.0 library for easily interacting with the BYOND DMI file format.
+### **DMISharp** is a .NET library targeting .NET 8 and .NET 10 for easily interacting with the BYOND DMI file format.
 
 Developed with ease-of-use in mind, this library provides a simple means for importing, modifying, and exporting DMI files. Internally, images are handled using [ImageSharp](https://github.com/SixLabors/ImageSharp), a fantastic open-source library from SixLabors.
 
@@ -85,6 +85,13 @@ newDMI.States.First().SetFrameCount(10);
 newDMI.Save(@"Data/Output/minecraft.dmi");
 ```
 
+### Development
+
+The test suite uses [TUnit](https://tunit.dev/) and runs on both supported target frameworks:
+
+```shell
+dotnet test --project DMISharp.Tests/DMISharp.Tests.csproj
+```
 
 ### Questions?
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,9 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}


### PR DESCRIPTION
## Summary

- target .NET 8 and .NET 10, dropping EOL .NET 6 and .NET 7
- upgrade ImageSharp to 3.1.12 and all other direct dependencies to their latest compatible stable versions
- migrate the test suite from xUnit/VSTest to TUnit 1.58.0 and Microsoft.Testing.Platform
- update CI, release, and BenchmarkDotNet configurations for .NET 8/.NET 10
- preserve existing PNG output size and performance with an explicit `PngFilterMethod.None`
- add regression coverage for representative PNG output sizes
- update the README with supported frameworks and the TUnit test command

## PNG regression root cause

ImageSharp 3.1.4 incorrectly ignored explicitly configured PNG filters. DMISharp requested `Adaptive`, but encoding effectively used `None`. ImageSharp fixed filter handling in commit `94f4083b70da72bbe2794b4c4db981ce43a37a11`, so 3.1.12 began honoring `Adaptive`; for sprite atlases this increased save time by 35–82% and expanded the sorted `animal.dmi` output from 134,673 to 209,006 bytes.

Explicitly selecting `None` preserves the behavior, output sizes, and performance users received from the previous release while allowing the dependency upgrade.

## Benchmarks

BenchmarkDotNet 0.15.8, Windows 11, Ryzen 7 5800X3D, .NET 8.0.28 / 10.0.9.

| PNG save workload | .NET 8 | .NET 10 | Change |
|---|---:|---:|---:|
| 256-frame palette atlas | 12.46 ms | 11.32 ms | -9.2% |
| 256-frame true-color atlas | 23.65 ms | 22.13 ms | -6.4% |

Managed allocations are effectively unchanged. Direct comparisons against current master on representative real files remain within approximately 0–3%, and output sizes are identical:

| File | Current master | Upgraded/fixed |
|---|---:|---:|
| `small.dmi` | 1,294 bytes | 1,294 bytes |
| `air_meter.dmi` | 481 bytes | 481 bytes |
| sorted `animal.dmi` | 134,673 bytes | 134,673 bytes |

The broader three-way suite also found .NET 10/latest dependencies improved reads by 17–41% and GIF construction by 18–55% versus merged master.

## Test infrastructure

The test project now uses TUnit's source-generated runner on Microsoft.Testing.Platform. `global.json` opts `dotnet test` into the .NET 10 MTP experience, CI uses the MTP `--project` syntax, and the obsolete xUnit runner, `Microsoft.NET.Test.Sdk`, and GitHub Actions VSTest logger dependencies are removed. File-writing tests remain serialized to preserve their existing output-file assumptions.

## Dependencies

ImageSharp 4.0 is intentionally excluded because it requires a configured Six Labors commercial or eligible open-source license key. ImageSharp 3.1.12 is the latest 3.x release and does not impose that new integration requirement. Remaining outdated entries are transitive dependencies controlled by their parent packages.

## Validation

- Release solution build succeeds for net8.0 and net10.0
- TUnit discovers and passes 40 tests on net8.0
- TUnit discovers and passes 40 tests on net10.0